### PR TITLE
Slice 3: Per-org encrypted credential store

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,14 @@ That brings up the production-shaped stack: a single Nexus container (Hono serve
 
 Override defaults via environment variables — `POSTGRES_PASSWORD`, `MINIO_ROOT_PASSWORD`, etc. See the top of [`docker-compose.yml`](./docker-compose.yml) for the full set.
 
+`CREDENTIAL_ENCRYPTION_KEY` encrypts per-org provider credentials at rest. Set it to a base64-encoded 32-byte secret in production:
+
+```bash
+export CREDENTIAL_ENCRYPTION_KEY=$(openssl rand -base64 32)
+```
+
+The compose file ships with a baked-in dev default so a clean checkout boots; rotating away from that default is a self-host step before storing real credentials.
+
 ## Layout
 
 ```

--- a/apps/server/drizzle/0001_credential.sql
+++ b/apps/server/drizzle/0001_credential.sql
@@ -1,0 +1,17 @@
+CREATE TABLE IF NOT EXISTS "credential" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"provider" text NOT NULL,
+	"name" text NOT NULL,
+	"value" "bytea" NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "credential" ADD CONSTRAINT "credential_org_id_org_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."org"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "credential_org_provider_name_unique" ON "credential" USING btree ("org_id","provider","name");

--- a/apps/server/drizzle/meta/0001_snapshot.json
+++ b/apps/server/drizzle/meta/0001_snapshot.json
@@ -1,0 +1,247 @@
+{
+  "id": "05949dfd-cc7a-4d5b-8144-3add5d6233af",
+  "prevId": "3d21d2a2-41ba-43e2-9f78-cb93003f9057",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credential_org_provider_name_unique": {
+          "name": "credential_org_provider_name_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credential_org_id_org_id_fk": {
+          "name": "credential_org_id_org_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health": {
+      "name": "health",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "booted_at": {
+          "name": "booted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org": {
+      "name": "org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_org_id_org_id_fk": {
+          "name": "user_org_id_org_id_fk",
+          "tableFrom": "user",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -8,6 +8,13 @@
       "when": 1777403994055,
       "tag": "0000_initial",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "7",
+      "when": 1777421351682,
+      "tag": "0001_credential",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -7,6 +7,7 @@
     "dev": "bun --hot src/index.ts",
     "start": "bun src/index.ts",
     "typecheck": "tsc --noEmit",
+    "test": "bun test src",
     "db:generate": "drizzle-kit generate",
     "db:migrate": "drizzle-kit migrate"
   },

--- a/apps/server/src/credentials/service.test.ts
+++ b/apps/server/src/credentials/service.test.ts
@@ -1,0 +1,101 @@
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import postgres from 'postgres';
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { runMigrations } from '../db/client.ts';
+import { org } from '../db/schema.ts';
+import { createCredentialService, type CredentialService } from './service.ts';
+
+const DATABASE_URL = process.env.TEST_DATABASE_URL ?? 'postgres://nexus:nexus@localhost:5432/nexus';
+// 32-byte key, base64-encoded — only used by tests
+const TEST_KEY = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=';
+
+let pool: ReturnType<typeof postgres>;
+let db: PostgresJsDatabase;
+let service: CredentialService;
+let orgId: string;
+
+beforeAll(async () => {
+  await runMigrations(DATABASE_URL);
+  pool = postgres(DATABASE_URL, { max: 5 });
+  db = drizzle(pool);
+  service = createCredentialService({ db, encryptionKey: TEST_KEY });
+});
+
+afterAll(async () => {
+  await pool.end();
+});
+
+beforeEach(async () => {
+  // Fresh org per test so rows don't collide.
+  const [row] = await db
+    .insert(org)
+    .values({ name: `test-org-${crypto.randomUUID()}` })
+    .returning({ id: org.id });
+  orgId = row!.id;
+});
+
+test('set -> get round-trips plaintext', async () => {
+  await service.set(orgId, 'twilio', 'auth_token', 'super-secret-value');
+  const value = await service.get(orgId, 'twilio', 'auth_token');
+  expect(value).toBe('super-secret-value');
+});
+
+test('get returns null for missing credential', async () => {
+  const value = await service.get(orgId, 'nope', 'nope');
+  expect(value).toBeNull();
+});
+
+test('set is upsert: setting same (provider, name) replaces value', async () => {
+  await service.set(orgId, 'twilio', 'auth_token', 'first');
+  await service.set(orgId, 'twilio', 'auth_token', 'second');
+  const value = await service.get(orgId, 'twilio', 'auth_token');
+  expect(value).toBe('second');
+});
+
+test('list returns provider+name pairs for the org only', async () => {
+  await service.set(orgId, 'twilio', 'auth_token', 'a');
+  await service.set(orgId, 'anthropic', 'api_key', 'b');
+
+  const [otherOrg] = await db
+    .insert(org)
+    .values({ name: `test-org-${crypto.randomUUID()}` })
+    .returning({ id: org.id });
+  await service.set(otherOrg!.id, 'twilio', 'auth_token', 'c');
+
+  const items = await service.list(orgId);
+  expect(items).toHaveLength(2);
+  const sorted = [...items].sort((x, y) => x.provider.localeCompare(y.provider));
+  expect(sorted).toEqual([
+    { provider: 'anthropic', name: 'api_key' },
+    { provider: 'twilio', name: 'auth_token' },
+  ]);
+});
+
+test('delete removes the row', async () => {
+  await service.set(orgId, 'twilio', 'auth_token', 'val');
+  await service.delete(orgId, 'twilio', 'auth_token');
+  const value = await service.get(orgId, 'twilio', 'auth_token');
+  expect(value).toBeNull();
+});
+
+test('factory rejects when encryption key is missing or wrong length', () => {
+  expect(() => createCredentialService({ db, encryptionKey: '' })).toThrow();
+  // 16 bytes base64 — not 32
+  expect(() => createCredentialService({ db, encryptionKey: 'AAECAwQFBgcICQoLDA0ODw==' })).toThrow();
+});
+
+test('value column is ciphertext at rest, not plaintext', async () => {
+  const plaintext = 'plaintext-marker-XYZ';
+  await service.set(orgId, 'anthropic', 'api_key', plaintext);
+
+  const rows = await pool<{ value: Buffer }[]>`
+    SELECT value FROM credential
+    WHERE org_id = ${orgId} AND provider = ${'anthropic'} AND name = ${'api_key'}
+  `;
+  expect(rows.length).toBe(1);
+  const stored = rows[0]!.value;
+  // Stored bytes must not contain the plaintext.
+  expect(stored.includes(Buffer.from(plaintext, 'utf8'))).toBe(false);
+  // And must not equal the plaintext when interpreted as utf8.
+  expect(stored.toString('utf8')).not.toBe(plaintext);
+});

--- a/apps/server/src/credentials/service.ts
+++ b/apps/server/src/credentials/service.ts
@@ -1,0 +1,104 @@
+import { createCipheriv, createDecipheriv, randomBytes } from 'node:crypto';
+import { and, eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { credential } from '../db/schema.ts';
+
+const ALGORITHM = 'aes-256-gcm';
+const IV_LEN = 12;
+const TAG_LEN = 16;
+const KEY_LEN = 32;
+
+export type CredentialService = {
+  set(orgId: string, provider: string, name: string, value: string): Promise<void>;
+  get(orgId: string, provider: string, name: string): Promise<string | null>;
+  list(orgId: string): Promise<Array<{ provider: string; name: string }>>;
+  delete(orgId: string, provider: string, name: string): Promise<void>;
+};
+
+type Deps = {
+  db: PostgresJsDatabase;
+  encryptionKey: string;
+};
+
+export function createCredentialService({ db, encryptionKey }: Deps): CredentialService {
+  const key = decodeKey(encryptionKey);
+
+  return {
+    async set(orgId, provider, name, value) {
+      const ciphertext = encrypt(key, value);
+      await db
+        .insert(credential)
+        .values({ orgId, provider, name, value: ciphertext })
+        .onConflictDoUpdate({
+          target: [credential.orgId, credential.provider, credential.name],
+          set: { value: ciphertext, updatedAt: new Date() },
+        });
+    },
+
+    async get(orgId, provider, name) {
+      const rows = await db
+        .select({ value: credential.value })
+        .from(credential)
+        .where(
+          and(
+            eq(credential.orgId, orgId),
+            eq(credential.provider, provider),
+            eq(credential.name, name),
+          ),
+        )
+        .limit(1);
+      const row = rows[0];
+      if (!row) return null;
+      return decrypt(key, row.value);
+    },
+
+    async list(orgId) {
+      return db
+        .select({ provider: credential.provider, name: credential.name })
+        .from(credential)
+        .where(eq(credential.orgId, orgId));
+    },
+
+    async delete(orgId, provider, name) {
+      await db
+        .delete(credential)
+        .where(
+          and(
+            eq(credential.orgId, orgId),
+            eq(credential.provider, provider),
+            eq(credential.name, name),
+          ),
+        );
+    },
+  };
+}
+
+function decodeKey(encoded: string): Buffer {
+  const buf = Buffer.from(encoded, 'base64');
+  if (buf.length !== KEY_LEN) {
+    throw new Error(
+      `credential encryption key must decode to ${KEY_LEN} bytes (got ${buf.length}); supply a base64-encoded 32-byte key`,
+    );
+  }
+  return buf;
+}
+
+function encrypt(key: Buffer, plaintext: string): Buffer {
+  const iv = randomBytes(IV_LEN);
+  const cipher = createCipheriv(ALGORITHM, key, iv);
+  const ct = Buffer.concat([cipher.update(plaintext, 'utf8'), cipher.final()]);
+  const tag = cipher.getAuthTag();
+  // Wire format: [iv (12)][tag (16)][ciphertext (n)]
+  return Buffer.concat([iv, tag, ct]);
+}
+
+function decrypt(key: Buffer, blob: Buffer | Uint8Array): string {
+  const buf = Buffer.isBuffer(blob) ? blob : Buffer.from(blob);
+  const iv = buf.subarray(0, IV_LEN);
+  const tag = buf.subarray(IV_LEN, IV_LEN + TAG_LEN);
+  const ct = buf.subarray(IV_LEN + TAG_LEN);
+  const decipher = createDecipheriv(ALGORITHM, key, iv);
+  decipher.setAuthTag(tag);
+  const pt = Buffer.concat([decipher.update(ct), decipher.final()]);
+  return pt.toString('utf8');
+}

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -1,4 +1,10 @@
-import { pgTable, uuid, text, timestamp, boolean } from 'drizzle-orm/pg-core';
+import { pgTable, uuid, text, timestamp, boolean, customType, uniqueIndex } from 'drizzle-orm/pg-core';
+
+const bytea = customType<{ data: Buffer; default: false }>({
+  dataType() {
+    return 'bytea';
+  },
+});
 
 export const org = pgTable('org', {
   id: uuid('id').primaryKey().defaultRandom(),
@@ -20,3 +26,25 @@ export const health = pgTable('health', {
   ok: boolean('ok').notNull().default(true),
   bootedAt: timestamp('booted_at', { withTimezone: true }).notNull().defaultNow(),
 });
+
+export const credential = pgTable(
+  'credential',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => org.id, { onDelete: 'cascade' }),
+    provider: text('provider').notNull(),
+    name: text('name').notNull(),
+    value: bytea('value').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    orgProviderNameUnique: uniqueIndex('credential_org_provider_name_unique').on(
+      t.orgId,
+      t.provider,
+      t.name,
+    ),
+  }),
+);

--- a/apps/server/src/env.test.ts
+++ b/apps/server/src/env.test.ts
@@ -1,0 +1,22 @@
+import { test, expect } from 'bun:test';
+import { loadEnv } from './env.ts';
+
+const baseEnv = {
+  DATABASE_URL: 'postgres://nexus:nexus@localhost:5432/nexus',
+  MINIO_ENDPOINT: 'minio',
+  MINIO_ACCESS_KEY: 'nexus',
+  MINIO_SECRET_KEY: 'nexus_dev_password_change_me',
+  MINIO_BUCKET: 'nexus',
+  EMBEDDING_URL: 'http://embedding:7997',
+  CREDENTIAL_ENCRYPTION_KEY: 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
+};
+
+test('loadEnv rejects when CREDENTIAL_ENCRYPTION_KEY is missing', () => {
+  const { CREDENTIAL_ENCRYPTION_KEY: _drop, ...without } = baseEnv;
+  expect(() => loadEnv(without)).toThrow();
+});
+
+test('loadEnv accepts a valid CREDENTIAL_ENCRYPTION_KEY', () => {
+  const env = loadEnv(baseEnv);
+  expect(env.CREDENTIAL_ENCRYPTION_KEY).toBe(baseEnv.CREDENTIAL_ENCRYPTION_KEY);
+});

--- a/apps/server/src/env.ts
+++ b/apps/server/src/env.ts
@@ -23,6 +23,7 @@ const EnvSchema = v.object({
   MINIO_SECRET_KEY: v.pipe(v.string(), v.minLength(1)),
   MINIO_BUCKET: v.pipe(v.string(), v.minLength(1)),
   EMBEDDING_URL: v.pipe(v.string(), v.url()),
+  CREDENTIAL_ENCRYPTION_KEY: v.pipe(v.string(), v.minLength(1)),
 });
 
 export type Env = v.InferOutput<typeof EnvSchema>;

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,21 +1,27 @@
 import { Hono } from 'hono';
 import { requestLogger } from '@nexus/logger/hono';
+import { log } from './logger.ts';
 import { loadEnv } from './env.ts';
 import { runMigrations, getDb, closeDb } from './db/client.ts';
 import { ensureBucket } from './storage/minio.ts';
 import { healthRoute } from './routes/health.ts';
 import { staticRoute } from './routes/static.ts';
-import { log } from './logger.ts';
+import { createCredentialService } from './credentials/service.ts';
 
 const env = loadEnv();
 
 await runMigrations(env.DATABASE_URL);
 await ensureBucket(env);
 
+const db = getDb(env.DATABASE_URL);
+// Instantiating here surfaces a bad CREDENTIAL_ENCRYPTION_KEY at startup
+// rather than on first credential write.
+createCredentialService({ db, encryptionKey: env.CREDENTIAL_ENCRYPTION_KEY });
+
 const app = new Hono();
 
 app.use('*', requestLogger({ logger: log }));
-app.route('/healthz', healthRoute({ env, db: getDb(env.DATABASE_URL) }));
+app.route('/healthz', healthRoute({ env, db }));
 app.route('/', staticRoute());
 
 const server = Bun.serve({

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,6 +24,7 @@ services:
       MINIO_SECRET_KEY: ${MINIO_ROOT_PASSWORD:-nexus_dev_password_change_me}
       MINIO_BUCKET: ${MINIO_BUCKET:-nexus}
       EMBEDDING_URL: http://embedding:7997
+      CREDENTIAL_ENCRYPTION_KEY: ${CREDENTIAL_ENCRYPTION_KEY:-AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=}
     ports:
       - "${NEXUS_PORT:-3000}:3000"
     restart: unless-stopped

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "prod": "docker compose up",
     "prod:down": "docker compose down",
     "smoke": "bun test tests/smoke.test.ts",
+    "test": "bun run --filter '*' test",
     "typecheck": "bun run --filter '*' typecheck",
     "build": "bun run --filter '*' build"
   },


### PR DESCRIPTION
## Summary

Adds the schema + service layer for storing per-org provider credentials encrypted at rest. Subsequent provider-integration slices (SMS/email/Telegram/voice) will read credentials through this store.

- `credential` table: scoped to `org_id`, `(provider, name)` unique per org, `value` is `bytea` ciphertext.
- AES-256-GCM with a random IV per write; key sourced from `CREDENTIAL_ENCRYPTION_KEY` (base64-encoded 32 bytes). Wrong-length or missing key fails server start-up before the HTTP listener binds.
- Service API: `set` (upsert), `get`, `list`, `delete`.

## Tests

Real Postgres, no mocks (per repo rules).

- Round-trip: `set` -> `get` -> assert plaintext matches.
- At-rest: read the row directly via raw SQL and assert the `value` bytea is not the plaintext.
- Plus: `get` on missing returns null, `set` is upsert, `list` is org-scoped, `delete` removes the row, factory rejects malformed keys.
- `env.test.ts`: `loadEnv` rejects when `CREDENTIAL_ENCRYPTION_KEY` is missing.

Manually verified `bun apps/server/src/index.ts` exits 1 with a Valibot error when the env var is unset.

## Test plan

- [x] `bun run typecheck` passes
- [x] `bun run test` passes (9 tests)
- [x] Existing `/healthz` smoke path still healthy after rebuild

Closes #4