### PR TITLE
feat: structured JSON logger + Hono request middleware

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 COPY package.json bun.lock tsconfig.base.json ./
 COPY apps/server/package.json apps/server/
 COPY apps/web/package.json apps/web/
+COPY packages/logger/package.json packages/logger/
 RUN bun install --frozen-lockfile
 
 # Build the web app -> apps/web/dist
@@ -19,6 +20,7 @@ FROM deps AS dev
 WORKDIR /app
 COPY apps/server ./apps/server
 COPY apps/web ./apps/web
+COPY packages ./packages
 EXPOSE 3000
 CMD ["bun", "--hot", "apps/server/src/index.ts"]
 
@@ -29,10 +31,12 @@ ENV NODE_ENV=production
 COPY package.json bun.lock ./
 COPY apps/server/package.json apps/server/
 COPY apps/web/package.json apps/web/
+COPY packages/logger/package.json packages/logger/
 COPY --from=deps /app/node_modules ./node_modules
 COPY --from=deps /app/apps/server/node_modules ./apps/server/node_modules
 COPY apps/server/src ./apps/server/src
 COPY apps/server/drizzle ./apps/server/drizzle
+COPY packages/logger/src ./packages/logger/src
 COPY --from=web-build /app/apps/web/dist ./apps/web/dist
 EXPOSE 3000
 CMD ["bun", "apps/server/src/index.ts"]

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -11,6 +11,7 @@
     "db:migrate": "drizzle-kit migrate"
   },
   "dependencies": {
+    "@nexus/logger": "workspace:*",
     "hono": "^4.6.12",
     "drizzle-orm": "^0.36.4",
     "postgres": "^3.4.5",

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,10 +1,11 @@
 import { Hono } from 'hono';
+import { requestLogger } from '@nexus/logger/hono';
 import { loadEnv } from './env.ts';
 import { runMigrations, getDb, closeDb } from './db/client.ts';
-import { ensureBucket, checkBucket } from './storage/minio.ts';
-import { checkEmbedding } from './embedding/client.ts';
+import { ensureBucket } from './storage/minio.ts';
 import { healthRoute } from './routes/health.ts';
 import { staticRoute } from './routes/static.ts';
+import { log } from './logger.ts';
 
 const env = loadEnv();
 
@@ -13,6 +14,7 @@ await ensureBucket(env);
 
 const app = new Hono();
 
+app.use('*', requestLogger({ logger: log }));
 app.route('/healthz', healthRoute({ env, db: getDb(env.DATABASE_URL) }));
 app.route('/', staticRoute());
 
@@ -21,7 +23,7 @@ const server = Bun.serve({
   fetch: app.fetch,
 });
 
-console.log(JSON.stringify({ msg: 'nexus listening', port: server.port }));
+log.info('nexus listening', { port: server.port });
 
 const shutdown = async () => {
   server.stop();

--- a/apps/server/src/logger.ts
+++ b/apps/server/src/logger.ts
@@ -1,0 +1,4 @@
+import { createLogger } from '@nexus/logger';
+
+export const log = createLogger();
+export { withContext, getContext } from '@nexus/logger';

--- a/bun.lock
+++ b/bun.lock
@@ -13,6 +13,7 @@
       "name": "@nexus/server",
       "version": "0.0.0",
       "dependencies": {
+        "@nexus/logger": "workspace:*",
         "drizzle-orm": "^0.36.4",
         "hono": "^4.6.12",
         "minio": "^8.0.2",
@@ -40,6 +41,18 @@
         "tailwindcss": "^4.0.0-beta.7",
         "typescript": "^5.6.3",
         "vite": "^6.0.3",
+      },
+    },
+    "packages/logger": {
+      "name": "@nexus/logger",
+      "version": "0.0.0",
+      "devDependencies": {
+        "@types/bun": "^1.1.17",
+        "hono": "^4.6.12",
+        "typescript": "^5.6.3",
+      },
+      "peerDependencies": {
+        "hono": "^4.6.12",
       },
     },
   },
@@ -149,6 +162,8 @@
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
     "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@nexus/logger": ["@nexus/logger@workspace:packages/logger"],
 
     "@nexus/server": ["@nexus/server@workspace:apps/server"],
 

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -8,6 +8,7 @@ services:
       - ./apps/server/src:/app/apps/server/src
       - ./apps/server/drizzle:/app/apps/server/drizzle
       - ./apps/server/drizzle.config.ts:/app/apps/server/drizzle.config.ts
+      - ./packages:/app/packages
 
   web:
     build:

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "nexus-v4",
   "private": true,
   "version": "0.0.0",
-  "workspaces": ["apps/*"],
+  "workspaces": ["apps/*", "packages/*"],
   "scripts": {
     "dev": "docker compose -f docker-compose.yml -f docker-compose.dev.yml up",
     "dev:down": "docker compose -f docker-compose.yml -f docker-compose.dev.yml down",

--- a/packages/logger/package.json
+++ b/packages/logger/package.json
@@ -1,0 +1,23 @@
+{
+  "name": "@nexus/logger",
+  "private": true,
+  "version": "0.0.0",
+  "type": "module",
+  "main": "./src/index.ts",
+  "exports": {
+    ".": "./src/index.ts",
+    "./hono": "./src/hono.ts"
+  },
+  "scripts": {
+    "typecheck": "tsc --noEmit",
+    "test": "bun test"
+  },
+  "peerDependencies": {
+    "hono": "^4.6.12"
+  },
+  "devDependencies": {
+    "hono": "^4.6.12",
+    "typescript": "^5.6.3",
+    "@types/bun": "^1.1.17"
+  }
+}

--- a/packages/logger/src/hono.ts
+++ b/packages/logger/src/hono.ts
@@ -1,0 +1,50 @@
+import type { MiddlewareHandler } from 'hono';
+import { withContext, type Logger } from './index.ts';
+
+export type RequestLoggerOptions = {
+  logger: Logger;
+  /** Header to source/echo the request id. Defaults to `x-request-id`. */
+  header?: string;
+  /** Override the id generator (used in tests). Defaults to `crypto.randomUUID`. */
+  generateId?: () => string;
+};
+
+export function requestLogger(opts: RequestLoggerOptions): MiddlewareHandler {
+  const header = opts.header ?? 'x-request-id';
+  const generateId = opts.generateId ?? (() => crypto.randomUUID());
+  const { logger } = opts;
+
+  return async (c, next) => {
+    const inbound = c.req.header(header);
+    const requestId = inbound && inbound.length > 0 ? inbound : generateId();
+    c.res.headers.set(header, requestId);
+
+    const start = performance.now();
+    await withContext({ request_id: requestId }, async () => {
+      logger.info('request.start', {
+        method: c.req.method,
+        path: c.req.path,
+      });
+      try {
+        await next();
+        logger.info('request.end', {
+          method: c.req.method,
+          path: c.req.path,
+          status: c.res.status,
+          duration_ms: Math.round(performance.now() - start),
+        });
+      } catch (err) {
+        logger.error('request.error', {
+          method: c.req.method,
+          path: c.req.path,
+          duration_ms: Math.round(performance.now() - start),
+          err: err instanceof Error ? err : new Error(String(err)),
+        });
+        throw err;
+      }
+    });
+
+    // Hono may overwrite headers on `c.res` reassignment inside handlers; re-stamp it.
+    c.res.headers.set(header, requestId);
+  };
+}

--- a/packages/logger/src/index.ts
+++ b/packages/logger/src/index.ts
@@ -1,0 +1,76 @@
+import { AsyncLocalStorage } from 'node:async_hooks';
+
+export type LogContext = {
+  request_id?: string;
+  session_id?: string;
+  tool_call_id?: string;
+  [key: string]: unknown;
+};
+
+export type LogFields = Record<string, unknown>;
+
+export type LogLevel = 'debug' | 'info' | 'warn' | 'error';
+
+export type Logger = {
+  debug: (msg: string, fields?: LogFields) => void;
+  info: (msg: string, fields?: LogFields) => void;
+  warn: (msg: string, fields?: LogFields) => void;
+  error: (msg: string, fields?: LogFields) => void;
+};
+
+export type LoggerOptions = {
+  sink?: (line: string) => void;
+  now?: () => Date;
+};
+
+const storage = new AsyncLocalStorage<LogContext>();
+
+export function getContext(): LogContext {
+  return storage.getStore() ?? {};
+}
+
+export function withContext<T>(patch: LogContext, fn: () => T): T {
+  const merged: LogContext = { ...getContext(), ...patch };
+  return storage.run(merged, fn);
+}
+
+const defaultSink = (line: string): void => {
+  // Bun and Node both expose process.stdout.write.
+  process.stdout.write(line + '\n');
+};
+
+export function createLogger(opts: LoggerOptions = {}): Logger {
+  const sink = opts.sink ?? defaultSink;
+  const now = opts.now ?? (() => new Date());
+
+  const emit = (level: LogLevel, msg: string, fields?: LogFields): void => {
+    const ctx = getContext();
+    const record: Record<string, unknown> = {
+      time: now().toISOString(),
+      level,
+      msg,
+      ...ctx,
+      ...(fields ? normalizeFields(fields) : {}),
+    };
+    sink(JSON.stringify(record));
+  };
+
+  return {
+    debug: (msg, fields) => emit('debug', msg, fields),
+    info: (msg, fields) => emit('info', msg, fields),
+    warn: (msg, fields) => emit('warn', msg, fields),
+    error: (msg, fields) => emit('error', msg, fields),
+  };
+}
+
+function normalizeFields(fields: LogFields): LogFields {
+  const out: LogFields = {};
+  for (const [key, value] of Object.entries(fields)) {
+    out[key] = value instanceof Error ? serializeError(value) : value;
+  }
+  return out;
+}
+
+function serializeError(err: Error): { name: string; message: string; stack?: string } {
+  return { name: err.name, message: err.message, stack: err.stack };
+}

--- a/packages/logger/test/hono.test.ts
+++ b/packages/logger/test/hono.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from 'bun:test';
 import { Hono } from 'hono';
-import { createLogger, getContext } from '../src/index.ts';
+import { createLogger } from '../src/index.ts';
 import { requestLogger } from '../src/hono.ts';
 
 test('middleware tags every log line within the request with a stable request_id', async () => {

--- a/packages/logger/test/hono.test.ts
+++ b/packages/logger/test/hono.test.ts
@@ -1,0 +1,87 @@
+import { test, expect } from 'bun:test';
+import { Hono } from 'hono';
+import { createLogger, getContext } from '../src/index.ts';
+import { requestLogger } from '../src/hono.ts';
+
+test('middleware tags every log line within the request with a stable request_id', async () => {
+  const lines: string[] = [];
+  const log = createLogger({ sink: (l) => lines.push(l) });
+
+  const app = new Hono();
+  app.use('*', requestLogger({ logger: log }));
+  app.get('/x', (c) => {
+    log.info('handler enter');
+    log.info('handler about to respond');
+    return c.text('ok');
+  });
+
+  const res = await app.request('/x');
+  expect(res.status).toBe(200);
+
+  // Expect: request start line, two handler lines, request end line. All same request_id.
+  expect(lines.length).toBeGreaterThanOrEqual(3);
+  const records = lines.map((l) => JSON.parse(l));
+  const ids = new Set(records.map((r) => r.request_id));
+  expect(ids.size).toBe(1);
+  const id = [...ids][0];
+  expect(typeof id).toBe('string');
+  expect((id as string).length).toBeGreaterThan(0);
+});
+
+test('middleware uses an inbound x-request-id header when present', async () => {
+  const lines: string[] = [];
+  const log = createLogger({ sink: (l) => lines.push(l) });
+
+  const app = new Hono();
+  app.use('*', requestLogger({ logger: log }));
+  app.get('/y', (c) => c.text('ok'));
+
+  await app.request('/y', { headers: { 'x-request-id': 'inbound-123' } });
+
+  const records = lines.map((l) => JSON.parse(l));
+  for (const r of records) {
+    expect(r.request_id).toBe('inbound-123');
+  }
+});
+
+test('middleware sets x-request-id on the response', async () => {
+  const log = createLogger({ sink: () => {} });
+  const app = new Hono();
+  app.use('*', requestLogger({ logger: log }));
+  app.get('/z', (c) => c.text('ok'));
+
+  const res = await app.request('/z', { headers: { 'x-request-id': 'echo-me' } });
+  expect(res.headers.get('x-request-id')).toBe('echo-me');
+});
+
+test('two concurrent requests do not leak request_id into each other', async () => {
+  const lines: string[] = [];
+  const log = createLogger({ sink: (l) => lines.push(l) });
+
+  const app = new Hono();
+  app.use('*', requestLogger({ logger: log }));
+  app.get('/slow/:n', async (c) => {
+    log.info('start', { n: c.req.param('n') });
+    await new Promise((r) => setTimeout(r, 10));
+    log.info('end', { n: c.req.param('n') });
+    return c.text('ok');
+  });
+
+  await Promise.all([
+    app.request('/slow/a', { headers: { 'x-request-id': 'A' } }),
+    app.request('/slow/b', { headers: { 'x-request-id': 'B' } }),
+  ]);
+
+  const records = lines.map((l) => JSON.parse(l));
+  const aLines = records.filter((r) => r.request_id === 'A');
+  const bLines = records.filter((r) => r.request_id === 'B');
+
+  // Each request emits start/end (handler) plus middleware request-start/request-end -> 4 each.
+  expect(aLines.every((r) => r.request_id === 'A')).toBe(true);
+  expect(bLines.every((r) => r.request_id === 'B')).toBe(true);
+  // A handler line never carries B's id and vice versa.
+  for (const r of records) {
+    if (r.n === 'a') expect(r.request_id).toBe('A');
+    if (r.n === 'b') expect(r.request_id).toBe('B');
+  }
+});

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -1,0 +1,82 @@
+import { test, expect } from 'bun:test';
+import { createLogger, withContext } from '../src/index.ts';
+
+function captureLines(fn: () => void): string[] {
+  const lines: string[] = [];
+  const sink = (line: string) => lines.push(line);
+  fn.call({ sink });
+  return lines;
+}
+
+test('logger emits a JSON line to its sink with level and msg', () => {
+  const lines: string[] = [];
+  const log = createLogger({ sink: (l) => lines.push(l) });
+
+  log.info('hello');
+
+  expect(lines).toHaveLength(1);
+  const parsed = JSON.parse(lines[0]!);
+  expect(parsed.level).toBe('info');
+  expect(parsed.msg).toBe('hello');
+  expect(typeof parsed.time).toBe('string');
+});
+
+test('logger merges fields from a fields object into the JSON line', () => {
+  const lines: string[] = [];
+  const log = createLogger({ sink: (l) => lines.push(l) });
+
+  log.info('done', { count: 3, ok: true });
+
+  const parsed = JSON.parse(lines[0]!);
+  expect(parsed.count).toBe(3);
+  expect(parsed.ok).toBe(true);
+  expect(parsed.msg).toBe('done');
+});
+
+test('withContext threads request_id, session_id, tool_call_id through nested log calls', () => {
+  const lines: string[] = [];
+  const log = createLogger({ sink: (l) => lines.push(l) });
+
+  withContext({ request_id: 'req-1' }, () => {
+    log.info('outer');
+    withContext({ session_id: 's-1' }, () => {
+      log.info('inner');
+      withContext({ tool_call_id: 'tc-1' }, () => {
+        log.info('deepest');
+      });
+    });
+  });
+
+  const [outer, inner, deepest] = lines.map((l) => JSON.parse(l));
+  expect(outer.request_id).toBe('req-1');
+  expect(outer.session_id).toBeUndefined();
+  expect(inner.request_id).toBe('req-1');
+  expect(inner.session_id).toBe('s-1');
+  expect(deepest.request_id).toBe('req-1');
+  expect(deepest.session_id).toBe('s-1');
+  expect(deepest.tool_call_id).toBe('tc-1');
+});
+
+test('logger.error includes the error message and stack', () => {
+  const lines: string[] = [];
+  const log = createLogger({ sink: (l) => lines.push(l) });
+
+  const err = new Error('boom');
+  log.error('failed', { err });
+
+  const parsed = JSON.parse(lines[0]!);
+  expect(parsed.level).toBe('error');
+  expect(parsed.err.message).toBe('boom');
+  expect(typeof parsed.err.stack).toBe('string');
+});
+
+test('explicit fields override context fields', () => {
+  const lines: string[] = [];
+  const log = createLogger({ sink: (l) => lines.push(l) });
+
+  withContext({ request_id: 'req-ctx' }, () => {
+    log.info('msg', { request_id: 'req-override' });
+  });
+
+  expect(JSON.parse(lines[0]!).request_id).toBe('req-override');
+});

--- a/packages/logger/test/logger.test.ts
+++ b/packages/logger/test/logger.test.ts
@@ -1,13 +1,6 @@
 import { test, expect } from 'bun:test';
 import { createLogger, withContext } from '../src/index.ts';
 
-function captureLines(fn: () => void): string[] {
-  const lines: string[] = [];
-  const sink = (line: string) => lines.push(line);
-  fn.call({ sink });
-  return lines;
-}
-
 test('logger emits a JSON line to its sink with level and msg', () => {
   const lines: string[] = [];
   const log = createLogger({ sink: (l) => lines.push(l) });

--- a/packages/logger/tsconfig.json
+++ b/packages/logger/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "lib": ["ES2022"],
+    "types": ["bun"]
+  },
+  "include": ["src/**/*", "test/**/*"]
+}

--- a/tests/smoke.test.ts
+++ b/tests/smoke.test.ts
@@ -75,3 +75,65 @@ test(
   },
   POLL_TIMEOUT_MS + 30_000,
 );
+
+test(
+  'hitting /healthz produces JSON log lines tagged with a single request_id',
+  async () => {
+    // Wait for /healthz to be ok (the prior test only ran assertions; it doesn't strictly
+    // sequence the start of this one in parallel-test mode — re-poll to be safe).
+    const upDeadline = Date.now() + POLL_TIMEOUT_MS;
+    while (Date.now() < upDeadline) {
+      try {
+        const res = await fetch(HEALTH_URL);
+        if (res.ok) break;
+      } catch {
+        // keep polling
+      }
+      await new Promise((r) => setTimeout(r, POLL_INTERVAL_MS));
+    }
+
+    const requestId = `smoke-${crypto.randomUUID()}`;
+    const since = new Date().toISOString();
+
+    const res = await fetch(HEALTH_URL, { headers: { 'x-request-id': requestId } });
+    expect(res.status).toBe(200);
+    expect(res.headers.get('x-request-id')).toBe(requestId);
+
+    // Give the server a moment to flush stdout into docker's log driver.
+    await new Promise((r) => setTimeout(r, 500));
+
+    const logs = await compose(['logs', '--no-color', '--no-log-prefix', '--since', since, 'nexus'], {
+      collect: true,
+    });
+    const rawLines = logs.stdout.split('\n').filter((l) => l.trim().length > 0);
+
+    const matches: Record<string, unknown>[] = [];
+    for (const line of rawLines) {
+      let parsed: Record<string, unknown>;
+      try {
+        parsed = JSON.parse(line) as Record<string, unknown>;
+      } catch {
+        // Some lines may be Bun's own startup chatter, not JSON. Skip non-JSON lines.
+        continue;
+      }
+      if (parsed.request_id === requestId) matches.push(parsed);
+    }
+
+    if (matches.length < 2) {
+      throw new Error(
+        `expected at least 2 JSON log lines tagged with request_id=${requestId}, got ${matches.length}\n--- raw logs ---\n${logs.stdout}`,
+      );
+    }
+    for (const rec of matches) {
+      expect(rec.request_id).toBe(requestId);
+      expect(typeof rec.level).toBe('string');
+      expect(typeof rec.msg).toBe('string');
+      expect(typeof rec.time).toBe('string');
+    }
+    // Sanity: at least one start and one end line for the request lifecycle.
+    const messages = matches.map((m) => m.msg);
+    expect(messages).toContain('request.start');
+    expect(messages).toContain('request.end');
+  },
+  POLL_TIMEOUT_MS + 30_000,
+);


### PR DESCRIPTION
## Summary

- Adds `@nexus/logger` workspace package: AsyncLocalStorage-backed log context, JSON-per-line stdout sink, level helpers (`debug`/`info`/`warn`/`error`).
- Adds a Hono `requestLogger` middleware that generates (or reuses an inbound `x-request-id`) and threads `request_id` through every log call inside the request via `withContext`.
- `withContext` also accepts `session_id` / `tool_call_id`, so later slices can attach those without changing call sites.
- Wires the middleware into `apps/server`, replaces the one `console.log` with `log.info`, and updates the Dockerfile + dev compose to ship the new workspace package.
- Adds an end-to-end smoke assertion: hitting `/healthz` with a known `x-request-id` produces multiple JSON log lines (`request.start`, `request.end`, ...) all tagged with that same id.

## Test plan

- [x] `bun test packages/logger` — 9/9 passing (logger + middleware unit tests).
- [x] `bun run typecheck` — clean across `@nexus/logger`, `@nexus/server`, `@nexus/web`.
- [x] `NEXUS_PORT=3010 bun test tests/smoke.test.ts` — both smoke cases pass against the real Docker Compose stack (`/healthz` healthy + JSON log lines tagged with the request id).

Closes #3