### PR TITLE
Slice 4: Auth + dashboard shell

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,6 +17,10 @@ npm-debug.log
 dist/
 apps/*/dist/
 
+# Playwright
+test-results/
+playwright-report/
+
 # Env
 .env
 .env.local

--- a/README.md
+++ b/README.md
@@ -84,3 +84,16 @@ bun run smoke
 ```
 
 Allow up to 5 minutes on a cold run (the embedding model is downloaded on first start). Subsequent runs reuse the cached model volume.
+
+## E2E test (auth + dashboard)
+
+Boots a one-off Postgres container, runs migrations, serves the auth API + the
+built React app on a single port, and drives a Chromium browser through register
+→ dashboard → logout → log back in:
+
+```bash
+bun run --filter @nexus/web build
+bun run e2e
+```
+
+The web build is a prerequisite — the e2e server serves `apps/web/dist`.

--- a/apps/server/drizzle/0002_auth.sql
+++ b/apps/server/drizzle/0002_auth.sql
@@ -1,0 +1,15 @@
+CREATE TABLE IF NOT EXISTS "session" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"user_id" uuid NOT NULL,
+	"token_hash" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "session_token_hash_unique" UNIQUE("token_hash")
+);
+--> statement-breakpoint
+ALTER TABLE "user" ADD COLUMN "password_hash" text NOT NULL;--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "session" ADD CONSTRAINT "session_user_id_user_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."user"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/apps/server/drizzle/meta/0002_snapshot.json
+++ b/apps/server/drizzle/meta/0002_snapshot.json
@@ -1,0 +1,320 @@
+{
+  "id": "5d348c80-08a0-4bed-9297-52e26015b346",
+  "prevId": "05949dfd-cc7a-4d5b-8144-3add5d6233af",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credential_org_provider_name_unique": {
+          "name": "credential_org_provider_name_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credential_org_id_org_id_fk": {
+          "name": "credential_org_id_org_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health": {
+      "name": "health",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "booted_at": {
+          "name": "booted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org": {
+      "name": "org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_hash_unique": {
+          "name": "session_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_org_id_org_id_fk": {
+          "name": "user_org_id_org_id_fk",
+          "tableFrom": "user",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -15,6 +15,13 @@
       "when": 1777421351682,
       "tag": "0001_credential",
       "breakpoints": true
+    },
+    {
+      "idx": 2,
+      "version": "7",
+      "when": 1777467011115,
+      "tag": "0002_auth",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -18,7 +18,18 @@ export const user = pgTable('user', {
     .notNull()
     .references(() => org.id, { onDelete: 'cascade' }),
   email: text('email').notNull().unique(),
+  passwordHash: text('password_hash').notNull(),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+export const session = pgTable('session', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  userId: uuid('user_id')
+    .notNull()
+    .references(() => user.id, { onDelete: 'cascade' }),
+  tokenHash: text('token_hash').notNull().unique(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
 });
 
 export const health = pgTable('health', {

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -5,8 +5,9 @@ import { loadEnv } from './env.ts';
 import { runMigrations, getDb, closeDb } from './db/client.ts';
 import { ensureBucket } from './storage/minio.ts';
 import { healthRoute } from './routes/health.ts';
-import { staticRoute } from './routes/static.ts';
+import { mountStatic } from './routes/static.ts';
 import { createCredentialService } from './credentials/service.ts';
+import { authRoute } from './routes/auth.ts';
 
 const env = loadEnv();
 
@@ -22,7 +23,8 @@ const app = new Hono();
 
 app.use('*', requestLogger({ logger: log }));
 app.route('/healthz', healthRoute({ env, db }));
-app.route('/', staticRoute());
+app.route('/api/auth', authRoute({ db }));
+mountStatic(app);
 
 const server = Bun.serve({
   port: env.PORT,

--- a/apps/server/src/routes/auth.test.ts
+++ b/apps/server/src/routes/auth.test.ts
@@ -1,0 +1,132 @@
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { authRoute } from './auth.ts';
+
+let pg: StartedPg;
+let app: Hono;
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+
+  app = new Hono();
+  app.route('/api/auth', authRoute({ db: getDb(pg.url) }));
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(sql`TRUNCATE TABLE "session", "user", "org" RESTART IDENTITY CASCADE`);
+});
+
+test('register creates org + user and sets a session cookie', async () => {
+  const res = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'op@example.com', password: 'hunter2hunter2' }),
+  });
+
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as { user: { id: string; email: string; orgId: string } };
+  expect(body.user.email).toBe('op@example.com');
+  expect(body.user.id).toMatch(/^[0-9a-f-]{36}$/);
+  expect(body.user.orgId).toMatch(/^[0-9a-f-]{36}$/);
+
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  expect(setCookie).toContain('nexus_session=');
+  expect(setCookie.toLowerCase()).toContain('httponly');
+});
+
+test('register → me returns the same user; logout clears the session', async () => {
+  const reg = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'op@example.com', password: 'hunter2hunter2' }),
+  });
+  const cookie = sessionCookie(reg);
+
+  const meOk = await app.request('/api/auth/me', { headers: { cookie } });
+  expect(meOk.status).toBe(200);
+  const meBody = (await meOk.json()) as { user: { email: string } };
+  expect(meBody.user.email).toBe('op@example.com');
+
+  const out = await app.request('/api/auth/logout', { method: 'POST', headers: { cookie } });
+  expect(out.status).toBe(200);
+
+  const meAfter = await app.request('/api/auth/me', { headers: { cookie } });
+  expect(meAfter.status).toBe(401);
+});
+
+test('login with the right password issues a fresh session; wrong password is rejected', async () => {
+  await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'op@example.com', password: 'hunter2hunter2' }),
+  });
+
+  const wrong = await app.request('/api/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'op@example.com', password: 'nope-nope-nope' }),
+  });
+  expect(wrong.status).toBe(401);
+
+  const right = await app.request('/api/auth/login', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'op@example.com', password: 'hunter2hunter2' }),
+  });
+  expect(right.status).toBe(200);
+  const cookie = sessionCookie(right);
+
+  const me = await app.request('/api/auth/me', { headers: { cookie } });
+  expect(me.status).toBe(200);
+});
+
+test('first registration creates a new org; second registration joins that org', async () => {
+  const r1 = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'first@example.com', password: 'hunter2hunter2' }),
+  });
+  expect(r1.status).toBe(201);
+  const u1 = (await r1.json()) as { user: { orgId: string } };
+
+  const r2 = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'second@example.com', password: 'hunter2hunter2' }),
+  });
+  expect(r2.status).toBe(201);
+  const u2 = (await r2.json()) as { user: { orgId: string } };
+
+  expect(u2.user.orgId).toBe(u1.user.orgId);
+});
+
+test('register rejects duplicate email', async () => {
+  await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'op@example.com', password: 'hunter2hunter2' }),
+  });
+  const dup = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email: 'op@example.com', password: 'hunter2hunter2' }),
+  });
+  expect(dup.status).toBe(409);
+});
+
+function sessionCookie(res: Response): string {
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  const match = /nexus_session=[^;]+/.exec(setCookie);
+  if (!match) throw new Error('no nexus_session cookie set');
+  return match[0];
+}

--- a/apps/server/src/routes/auth.ts
+++ b/apps/server/src/routes/auth.ts
@@ -1,0 +1,164 @@
+import { Hono, type Context } from 'hono';
+import { setCookie, deleteCookie, getCookie } from 'hono/cookie';
+import * as v from 'valibot';
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { org, user, session } from '../db/schema.ts';
+
+const SESSION_COOKIE = 'nexus_session';
+const SESSION_TTL_MS = 1000 * 60 * 60 * 24 * 30; // 30 days
+
+const Credentials = v.object({
+  email: v.pipe(v.string(), v.email()),
+  password: v.pipe(v.string(), v.minLength(8), v.maxLength(200)),
+});
+
+type Deps = { db: PostgresJsDatabase };
+
+export function authRoute({ db }: Deps) {
+  const router = new Hono();
+
+  router.post('/register', async (c) => {
+    const json = await safeJson(c.req.raw);
+    const parsed = v.safeParse(Credentials, json);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_credentials_shape' }, 400);
+    }
+    const { email, password } = parsed.output;
+    const normalized = email.toLowerCase();
+
+    const existing = await db.select().from(user).where(eq(user.email, normalized)).limit(1);
+    if (existing.length > 0) {
+      return c.json({ error: 'email_taken' }, 409);
+    }
+
+    // First user in an empty org space auto-creates the org and joins it.
+    // Subsequent users join the existing single org. Multi-org will arrive in a later slice.
+    let orgRow = (await db.select().from(org).limit(1))[0];
+    if (!orgRow) {
+      const inserted = await db
+        .insert(org)
+        .values({ name: deriveOrgName(normalized) })
+        .returning();
+      orgRow = inserted[0]!;
+    }
+
+    const passwordHash = await Bun.password.hash(password);
+    const [created] = await db
+      .insert(user)
+      .values({ orgId: orgRow.id, email: normalized, passwordHash })
+      .returning();
+
+    const token = await issueSession(db, created!.id);
+    setSessionCookie(c, token);
+
+    return c.json(
+      { user: { id: created!.id, email: created!.email, orgId: created!.orgId } },
+      201,
+    );
+  });
+
+  router.post('/login', async (c) => {
+    const json = await safeJson(c.req.raw);
+    const parsed = v.safeParse(Credentials, json);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_credentials_shape' }, 400);
+    }
+    const { email, password } = parsed.output;
+    const normalized = email.toLowerCase();
+
+    const [row] = await db.select().from(user).where(eq(user.email, normalized)).limit(1);
+    if (!row) {
+      return c.json({ error: 'invalid_credentials' }, 401);
+    }
+    const ok = await Bun.password.verify(password, row.passwordHash);
+    if (!ok) {
+      return c.json({ error: 'invalid_credentials' }, 401);
+    }
+
+    const token = await issueSession(db, row.id);
+    setSessionCookie(c, token);
+
+    return c.json({ user: { id: row.id, email: row.email, orgId: row.orgId } }, 200);
+  });
+
+  router.post('/logout', async (c) => {
+    const token = getCookie(c, SESSION_COOKIE);
+    if (token) {
+      await db.delete(session).where(eq(session.tokenHash, hashToken(token)));
+    }
+    deleteCookie(c, SESSION_COOKIE, { path: '/' });
+    return c.json({ ok: true }, 200);
+  });
+
+  router.get('/me', async (c) => {
+    const token = getCookie(c, SESSION_COOKIE);
+    if (!token) {
+      return c.json({ error: 'unauthenticated' }, 401);
+    }
+    const [row] = await db
+      .select({
+        userId: user.id,
+        email: user.email,
+        orgId: user.orgId,
+        expiresAt: session.expiresAt,
+      })
+      .from(session)
+      .innerJoin(user, eq(session.userId, user.id))
+      .where(eq(session.tokenHash, hashToken(token)))
+      .limit(1);
+
+    if (!row || row.expiresAt.getTime() < Date.now()) {
+      return c.json({ error: 'unauthenticated' }, 401);
+    }
+    return c.json({ user: { id: row.userId, email: row.email, orgId: row.orgId } }, 200);
+  });
+
+  return router;
+}
+
+function deriveOrgName(email: string): string {
+  const local = email.split('@')[0] ?? 'workspace';
+  return `${local}'s workspace`;
+}
+
+async function issueSession(db: PostgresJsDatabase, userId: string): Promise<string> {
+  const token = randomToken();
+  await db.insert(session).values({
+    userId,
+    tokenHash: hashToken(token),
+    expiresAt: new Date(Date.now() + SESSION_TTL_MS),
+  });
+  return token;
+}
+
+function randomToken(): string {
+  // 32 bytes -> 64 hex chars; opaque to clients.
+  const bytes = new Uint8Array(32);
+  crypto.getRandomValues(bytes);
+  return Array.from(bytes, (b) => b.toString(16).padStart(2, '0')).join('');
+}
+
+function hashToken(token: string): string {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(token);
+  return hasher.digest('hex');
+}
+
+function setSessionCookie(c: Context, token: string): void {
+  setCookie(c, SESSION_COOKIE, token, {
+    httpOnly: true,
+    sameSite: 'Lax',
+    path: '/',
+    secure: false,
+    maxAge: Math.floor(SESSION_TTL_MS / 1000),
+  });
+}
+
+async function safeJson(req: Request): Promise<unknown> {
+  try {
+    return await req.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/server/src/routes/static.ts
+++ b/apps/server/src/routes/static.ts
@@ -1,26 +1,32 @@
-import { Hono } from 'hono';
+import type { Hono } from 'hono';
 import { serveStatic } from 'hono/bun';
 import { existsSync } from 'node:fs';
+import { readFile } from 'node:fs/promises';
 import { resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const here = fileURLToPath(import.meta.url);
 const distRoot = resolve(here, '../../../../web/dist');
+const indexPath = `${distRoot}/index.html`;
 
-export function staticRoute() {
-  const router = new Hono();
-
+// Mounts static-asset serving + SPA fallback on the app. Real files in
+// apps/web/dist are served as-is. Anything else (including client-side
+// routes like /login) returns the SPA index.html so the React router can
+// take it from there.
+export function mountStatic(app: Hono): void {
   if (!existsSync(distRoot)) {
-    router.get('*', (c) =>
+    app.notFound((c) =>
       c.text(
         'Frontend not built. In dev, visit the Vite server. In prod, the image should include apps/web/dist.',
         404,
       ),
     );
-    return router;
+    return;
   }
 
-  router.use('/*', serveStatic({ root: distRoot }));
-  router.get('*', serveStatic({ path: `${distRoot}/index.html` }));
-  return router;
+  app.use('*', serveStatic({ root: distRoot }));
+  app.notFound(async (c) => {
+    const html = await readFile(indexPath, 'utf-8');
+    return c.html(html, 200);
+  });
 }

--- a/apps/server/src/test-helpers/e2e-server.ts
+++ b/apps/server/src/test-helpers/e2e-server.ts
@@ -1,0 +1,37 @@
+// Minimal end-to-end server that backs the Playwright test:
+//   - Boots a Postgres container.
+//   - Runs Drizzle migrations.
+//   - Serves the auth API and the built Vite dist on a single port.
+//
+// Started by playwright.config.ts via the webServer option, killed when the
+// run finishes.
+
+import { Hono } from 'hono';
+import { startPg } from './pg-container.ts';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { authRoute } from '../routes/auth.ts';
+import { mountStatic } from '../routes/static.ts';
+
+const port = Number.parseInt(process.env.E2E_PORT ?? '4173', 10);
+
+const pg = await startPg();
+console.log(`[e2e] postgres up at ${pg.url}`);
+await runMigrations(pg.url);
+
+const app = new Hono();
+const db = getDb(pg.url);
+
+app.route('/api/auth', authRoute({ db }));
+mountStatic(app);
+
+const server = Bun.serve({ port, fetch: app.fetch });
+console.log(`[e2e] listening on http://localhost:${server.port}`);
+
+const shutdown = async () => {
+  server.stop();
+  await closeDb();
+  await pg.stop();
+  process.exit(0);
+};
+process.on('SIGTERM', shutdown);
+process.on('SIGINT', shutdown);

--- a/apps/server/src/test-helpers/pg-container.ts
+++ b/apps/server/src/test-helpers/pg-container.ts
@@ -1,0 +1,121 @@
+// Tiny helper that boots a one-off Postgres container via `docker run` for tests.
+// We don't use testcontainers-node because it occasionally hangs under Bun
+// on macOS while validating the listening-ports wait strategy.
+
+const IMAGE = 'postgres:16-alpine';
+
+export type StartedPg = {
+  url: string;
+  stop: () => Promise<void>;
+};
+
+export async function startPg(): Promise<StartedPg> {
+  const name = `nexus-test-${crypto.randomUUID()}`;
+  const proc = Bun.spawn(
+    [
+      'docker',
+      'run',
+      '--rm',
+      '-d',
+      '--name',
+      name,
+      '-e',
+      'POSTGRES_PASSWORD=test',
+      '-e',
+      'POSTGRES_USER=test',
+      '-e',
+      'POSTGRES_DB=test',
+      '-P',
+      IMAGE,
+    ],
+    { stdout: 'pipe', stderr: 'pipe' },
+  );
+  const code = await proc.exited;
+  const stdout = await new Response(proc.stdout).text();
+  const stderr = await new Response(proc.stderr).text();
+  if (code !== 0) {
+    throw new Error(`docker run failed (${code}): ${stderr}`);
+  }
+  const id = stdout.trim();
+
+  const port = await waitForPort(id);
+  await waitForReady(id);
+
+  const url = `postgres://test:test@127.0.0.1:${port}/test`;
+  await waitForConnect(url);
+  return {
+    url,
+    stop: async () => {
+      const s = Bun.spawn(['docker', 'rm', '-f', id], { stdout: 'pipe', stderr: 'pipe' });
+      await s.exited;
+    },
+  };
+}
+
+async function waitForConnect(url: string): Promise<void> {
+  // Even after pg_isready and TCP port are up, postgres may still report
+  // "the database system is starting up" to incoming connections for a moment.
+  // Poll with a real query until we get a clean answer.
+  const { default: postgres } = await import('postgres');
+  const deadline = Date.now() + 30_000;
+  let lastErr: unknown;
+  while (Date.now() < deadline) {
+    const sql = postgres(url, { max: 1, idle_timeout: 1, connect_timeout: 5 });
+    try {
+      await sql`SELECT 1`;
+      await sql.end();
+      return;
+    } catch (err) {
+      lastErr = err;
+      try {
+        await sql.end();
+      } catch {
+        /* ignore */
+      }
+      await sleep(250);
+    }
+  }
+  throw new Error(
+    `postgres never accepted a query: ${lastErr instanceof Error ? lastErr.message : String(lastErr)}`,
+  );
+}
+
+async function waitForPort(id: string): Promise<number> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const proc = Bun.spawn(['docker', 'port', id, '5432/tcp'], {
+      stdout: 'pipe',
+      stderr: 'pipe',
+    });
+    const code = await proc.exited;
+    if (code === 0) {
+      const out = (await new Response(proc.stdout).text()).trim();
+      // Lines like "0.0.0.0:55003" or "[::]:55003"; pick first IPv4 mapping.
+      const line = out.split('\n').find((l) => l.includes('0.0.0.0:'));
+      if (line) {
+        const port = Number.parseInt(line.split(':').pop() ?? '', 10);
+        if (Number.isFinite(port)) return port;
+      }
+    }
+    await sleep(200);
+  }
+  throw new Error('postgres port mapping never appeared');
+}
+
+async function waitForReady(id: string): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const proc = Bun.spawn(
+      ['docker', 'exec', id, 'pg_isready', '-U', 'test', '-d', 'test'],
+      { stdout: 'pipe', stderr: 'pipe' },
+    );
+    const code = await proc.exited;
+    if (code === 0) return;
+    await sleep(250);
+  }
+  throw new Error('postgres never became ready');
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((r) => setTimeout(r, ms));
+}

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -11,7 +11,8 @@
   },
   "dependencies": {
     "react": "^19.0.0",
-    "react-dom": "^19.0.0"
+    "react-dom": "^19.0.0",
+    "react-router-dom": "^7.1.0"
   },
   "devDependencies": {
     "@types/react": "^19.0.1",

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,67 +1,43 @@
-import { useEffect, useState } from 'react';
-
-type HealthCheck = { ok: boolean; error?: string };
-type HealthResponse = {
-  ok: boolean;
-  postgres: HealthCheck;
-  minio: HealthCheck;
-  embedding: HealthCheck;
-};
-
-type Status = { state: 'loading' } | { state: 'ok'; data: HealthResponse } | { state: 'error'; error: string };
+import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router-dom';
+import { AuthProvider, useAuth } from './auth/auth';
+import { AppShell } from './layout/AppShell';
+import { Dashboard } from './pages/Dashboard';
+import { Login } from './pages/Login';
+import { Register } from './pages/Register';
 
 export function App() {
-  const [status, setStatus] = useState<Status>({ state: 'loading' });
-
-  useEffect(() => {
-    let cancelled = false;
-    fetch('/healthz')
-      .then(async (res) => {
-        const data = (await res.json()) as HealthResponse;
-        if (!cancelled) setStatus({ state: 'ok', data });
-      })
-      .catch((err: unknown) => {
-        if (!cancelled) {
-          setStatus({ state: 'error', error: err instanceof Error ? err.message : String(err) });
-        }
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, []);
-
   return (
-    <main className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center p-8">
-      <div className="max-w-md w-full space-y-6">
-        <h1 className="text-3xl font-semibold tracking-tight">Nexus</h1>
-        <p className="text-zinc-400 text-sm">Self-hosted agents platform · slice 1 placeholder</p>
-        <section className="rounded-lg border border-zinc-800 bg-zinc-900/50 p-4 space-y-2">
-          <h2 className="text-sm uppercase tracking-wide text-zinc-500">Health</h2>
-          {status.state === 'loading' && <p className="text-zinc-400">Checking…</p>}
-          {status.state === 'error' && <p className="text-red-400">Failed: {status.error}</p>}
-          {status.state === 'ok' && <HealthList data={status.data} />}
-        </section>
-      </div>
-    </main>
+    <AuthProvider>
+      <BrowserRouter>
+        <Routes>
+          <Route path="/login" element={<Login />} />
+          <Route path="/register" element={<Register />} />
+          <Route element={<RequireAuth />}>
+            <Route element={<AppShell />}>
+              <Route index element={<Dashboard />} />
+            </Route>
+          </Route>
+          <Route path="*" element={<Navigate to="/" replace />} />
+        </Routes>
+      </BrowserRouter>
+    </AuthProvider>
   );
 }
 
-function HealthList({ data }: { data: HealthResponse }) {
-  const rows: Array<[string, HealthCheck]> = [
-    ['Postgres', data.postgres],
-    ['MinIO', data.minio],
-    ['Embedding', data.embedding],
-  ];
-  return (
-    <ul className="space-y-1.5 text-sm">
-      {rows.map(([name, check]) => (
-        <li key={name} className="flex items-center justify-between gap-3">
-          <span>{name}</span>
-          <span className={check.ok ? 'text-emerald-400' : 'text-red-400'}>
-            {check.ok ? 'ok' : (check.error ?? 'down')}
-          </span>
-        </li>
-      ))}
-    </ul>
-  );
+function RequireAuth() {
+  const { state } = useAuth();
+  if (state.status === 'loading') {
+    return (
+      <div
+        data-testid="auth-loading"
+        className="min-h-screen bg-zinc-950 text-zinc-400 flex items-center justify-center"
+      >
+        Loading…
+      </div>
+    );
+  }
+  if (state.status === 'signed-out') {
+    return <Navigate to="/login" replace />;
+  }
+  return <Outlet />;
 }

--- a/apps/web/src/auth/auth.tsx
+++ b/apps/web/src/auth/auth.tsx
@@ -1,0 +1,103 @@
+import { createContext, useCallback, useContext, useEffect, useMemo, useState, type ReactNode } from 'react';
+
+export type AuthUser = { id: string; email: string; orgId: string };
+
+type AuthState =
+  | { status: 'loading' }
+  | { status: 'signed-in'; user: AuthUser }
+  | { status: 'signed-out' };
+
+type AuthContextValue = {
+  state: AuthState;
+  register: (email: string, password: string) => Promise<void>;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+};
+
+const AuthContext = createContext<AuthContextValue | null>(null);
+
+export function AuthProvider({ children }: { children: ReactNode }) {
+  const [state, setState] = useState<AuthState>({ status: 'loading' });
+
+  const refresh = useCallback(async () => {
+    try {
+      const res = await fetch('/api/auth/me', { credentials: 'same-origin' });
+      if (res.ok) {
+        const body = (await res.json()) as { user: AuthUser };
+        setState({ status: 'signed-in', user: body.user });
+      } else {
+        setState({ status: 'signed-out' });
+      }
+    } catch {
+      setState({ status: 'signed-out' });
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  const register = useCallback(
+    async (email: string, password: string) => {
+      const res = await fetch('/api/auth/register', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        throw new Error(await readError(res, 'Registration failed'));
+      }
+      const body = (await res.json()) as { user: AuthUser };
+      setState({ status: 'signed-in', user: body.user });
+    },
+    [],
+  );
+
+  const login = useCallback(
+    async (email: string, password: string) => {
+      const res = await fetch('/api/auth/login', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ email, password }),
+      });
+      if (!res.ok) {
+        throw new Error(await readError(res, 'Login failed'));
+      }
+      const body = (await res.json()) as { user: AuthUser };
+      setState({ status: 'signed-in', user: body.user });
+    },
+    [],
+  );
+
+  const logout = useCallback(async () => {
+    await fetch('/api/auth/logout', { method: 'POST', credentials: 'same-origin' });
+    setState({ status: 'signed-out' });
+  }, []);
+
+  const value = useMemo<AuthContextValue>(
+    () => ({ state, register, login, logout }),
+    [state, register, login, logout],
+  );
+
+  return <AuthContext.Provider value={value}>{children}</AuthContext.Provider>;
+}
+
+export function useAuth(): AuthContextValue {
+  const ctx = useContext(AuthContext);
+  if (!ctx) throw new Error('useAuth must be used inside <AuthProvider>');
+  return ctx;
+}
+
+async function readError(res: Response, fallback: string): Promise<string> {
+  try {
+    const body = (await res.json()) as { error?: string };
+    if (body.error === 'invalid_credentials') return 'Invalid email or password.';
+    if (body.error === 'email_taken') return 'An account with that email already exists.';
+    if (body.error === 'invalid_credentials_shape') return 'Email and an 8+ character password are required.';
+    return body.error ?? fallback;
+  } catch {
+    return fallback;
+  }
+}

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -1,0 +1,51 @@
+import { NavLink, Outlet } from 'react-router-dom';
+import { useAuth } from '../auth/auth';
+
+export function AppShell() {
+  const { state, logout } = useAuth();
+  const email = state.status === 'signed-in' ? state.user.email : '';
+
+  return (
+    <div className="min-h-screen bg-zinc-950 text-zinc-100 flex">
+      <aside className="w-56 shrink-0 border-r border-zinc-800 bg-zinc-900/40 p-4 flex flex-col">
+        <div className="px-2 py-1 text-lg font-semibold tracking-tight">Nexus</div>
+        <nav className="mt-4 space-y-1 text-sm">
+          <SideLink to="/" label="Dashboard" />
+        </nav>
+        <div className="mt-auto pt-4 border-t border-zinc-800 text-xs text-zinc-400">
+          <div data-testid="signed-in-as" className="px-2 truncate">
+            {email}
+          </div>
+          <button
+            type="button"
+            onClick={() => {
+              void logout();
+            }}
+            className="mt-2 w-full rounded-md border border-zinc-700 px-2 py-1.5 text-left text-sm text-zinc-200 hover:bg-zinc-800"
+          >
+            Log out
+          </button>
+        </div>
+      </aside>
+      <main className="flex-1 p-8">
+        <Outlet />
+      </main>
+    </div>
+  );
+}
+
+function SideLink({ to, label }: { to: string; label: string }) {
+  return (
+    <NavLink
+      to={to}
+      end
+      className={({ isActive }) =>
+        `block rounded-md px-2 py-1.5 ${
+          isActive ? 'bg-zinc-800 text-zinc-50' : 'text-zinc-300 hover:bg-zinc-800/60'
+        }`
+      }
+    >
+      {label}
+    </NavLink>
+  );
+}

--- a/apps/web/src/pages/Dashboard.tsx
+++ b/apps/web/src/pages/Dashboard.tsx
@@ -1,0 +1,10 @@
+export function Dashboard() {
+  return (
+    <section data-testid="dashboard" className="space-y-2">
+      <h1 className="text-2xl font-semibold tracking-tight">Dashboard</h1>
+      <p className="text-zinc-400 text-sm">
+        You're signed in. Agents, channels, and conversations will live here.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/src/pages/Login.tsx
+++ b/apps/web/src/pages/Login.tsx
@@ -1,0 +1,102 @@
+import { useState, type FormEvent } from 'react';
+import { Link, Navigate, useNavigate } from 'react-router-dom';
+import { useAuth } from '../auth/auth';
+
+export function Login() {
+  const { state, login } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (state.status === 'signed-in') {
+    return <Navigate to="/" replace />;
+  }
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      await login(email, password);
+      navigate('/', { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Login failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthCard title="Sign in to Nexus">
+      <form onSubmit={onSubmit} className="space-y-3">
+        <Field label="Email" type="email" value={email} onChange={setEmail} autoComplete="email" />
+        <Field
+          label="Password"
+          type="password"
+          value={password}
+          onChange={setPassword}
+          autoComplete="current-password"
+        />
+        {error && (
+          <p role="alert" className="text-sm text-red-400">
+            {error}
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full rounded-md bg-emerald-500 px-3 py-2 text-sm font-medium text-zinc-950 hover:bg-emerald-400 disabled:opacity-60"
+        >
+          {submitting ? 'Signing in…' : 'Sign in'}
+        </button>
+      </form>
+      <p className="mt-4 text-sm text-zinc-400">
+        New here?{' '}
+        <Link to="/register" className="text-emerald-400 hover:underline">
+          Create an account
+        </Link>
+      </p>
+    </AuthCard>
+  );
+}
+
+export function AuthCard({ title, children }: { title: string; children: React.ReactNode }) {
+  return (
+    <main className="min-h-screen bg-zinc-950 text-zinc-100 flex items-center justify-center p-8">
+      <div className="w-full max-w-sm rounded-lg border border-zinc-800 bg-zinc-900/50 p-6 space-y-5">
+        <h1 className="text-xl font-semibold tracking-tight">{title}</h1>
+        {children}
+      </div>
+    </main>
+  );
+}
+
+export function Field({
+  label,
+  type,
+  value,
+  onChange,
+  autoComplete,
+}: {
+  label: string;
+  type: 'email' | 'password' | 'text';
+  value: string;
+  onChange: (next: string) => void;
+  autoComplete?: string;
+}) {
+  return (
+    <label className="block text-sm">
+      <span className="block text-zinc-300 mb-1">{label}</span>
+      <input
+        type={type}
+        value={value}
+        autoComplete={autoComplete}
+        required
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-zinc-100 outline-none focus:border-emerald-500"
+      />
+    </label>
+  );
+}

--- a/apps/web/src/pages/Register.tsx
+++ b/apps/web/src/pages/Register.tsx
@@ -1,0 +1,64 @@
+import { useState, type FormEvent } from 'react';
+import { Link, Navigate, useNavigate } from 'react-router-dom';
+import { useAuth } from '../auth/auth';
+import { AuthCard, Field } from './Login';
+
+export function Register() {
+  const { state, register } = useAuth();
+  const navigate = useNavigate();
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (state.status === 'signed-in') {
+    return <Navigate to="/" replace />;
+  }
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      await register(email, password);
+      navigate('/', { replace: true });
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Registration failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <AuthCard title="Create your Nexus account">
+      <form onSubmit={onSubmit} className="space-y-3">
+        <Field label="Email" type="email" value={email} onChange={setEmail} autoComplete="email" />
+        <Field
+          label="Password (8+ characters)"
+          type="password"
+          value={password}
+          onChange={setPassword}
+          autoComplete="new-password"
+        />
+        {error && (
+          <p role="alert" className="text-sm text-red-400">
+            {error}
+          </p>
+        )}
+        <button
+          type="submit"
+          disabled={submitting}
+          className="w-full rounded-md bg-emerald-500 px-3 py-2 text-sm font-medium text-zinc-950 hover:bg-emerald-400 disabled:opacity-60"
+        >
+          {submitting ? 'Creating account…' : 'Create account'}
+        </button>
+      </form>
+      <p className="mt-4 text-sm text-zinc-400">
+        Already have one?{' '}
+        <Link to="/login" className="text-emerald-400 hover:underline">
+          Sign in
+        </Link>
+      </p>
+    </AuthCard>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "nexus-v4",
       "devDependencies": {
+        "@playwright/test": "^1.49.0",
         "@types/bun": "^1.1.17",
         "typescript": "^5.6.3",
       },
@@ -32,6 +33,7 @@
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
+        "react-router-dom": "^7.1.0",
       },
       "devDependencies": {
         "@tailwindcss/vite": "^4.0.0-beta.7",
@@ -171,6 +173,8 @@
 
     "@nodable/entities": ["@nodable/entities@2.1.0", "", {}, "sha512-nyT7T3nbMyBI/lvr6L5TyWbFJAI9FTgVRakNoBqCD+PmID8DzFrrNdLLtHMwMszOtqZa8PAOV24ZqDnQrhQINA=="],
 
+    "@playwright/test": ["@playwright/test@1.59.1", "", { "dependencies": { "playwright": "1.59.1" }, "bin": { "playwright": "cli.js" } }, "sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg=="],
+
     "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.0-beta.27", "", {}, "sha512-+d0F4MKMCbeVUJwG96uQ4SgAznZNSq93I3V+9NHA4OpvqG8mRCpGdKmK8l/dl02h2CCDHwW2FqilnTyDcAnqjA=="],
 
     "@rollup/rollup-android-arm-eabi": ["@rollup/rollup-android-arm-eabi@4.60.2", "", { "os": "android", "cpu": "arm" }, "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw=="],
@@ -293,6 +297,8 @@
 
     "convert-source-map": ["convert-source-map@2.0.0", "", {}, "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg=="],
 
+    "cookie": ["cookie@1.1.1", "", {}, "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ=="],
+
     "csstype": ["csstype@3.2.3", "", {}, "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
@@ -395,6 +401,10 @@
 
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
+    "playwright": ["playwright@1.59.1", "", { "dependencies": { "playwright-core": "1.59.1" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw=="],
+
+    "playwright-core": ["playwright-core@1.59.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg=="],
+
     "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
@@ -406,6 +416,10 @@
     "react-dom": ["react-dom@19.2.5", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.5" } }, "sha512-J5bAZz+DXMMwW/wV3xzKke59Af6CHY7G4uYLN1OvBcKEsWOs4pQExj86BBKamxl/Ik5bx9whOrvBlSDfWzgSag=="],
 
     "react-refresh": ["react-refresh@0.17.0", "", {}, "sha512-z6F7K9bV85EfseRCp2bzrpyQ0Gkw1uLoCel9XBVWPg/TjRj94SkJzUTGfOa4bs7iJvBWtQG0Wq7wnI0syw3EBQ=="],
+
+    "react-router": ["react-router@7.14.2", "", { "dependencies": { "cookie": "^1.0.1", "set-cookie-parser": "^2.6.0" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" }, "optionalPeers": ["react-dom"] }, "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw=="],
+
+    "react-router-dom": ["react-router-dom@7.14.2", "", { "dependencies": { "react-router": "7.14.2" }, "peerDependencies": { "react": ">=18", "react-dom": ">=18" } }, "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ=="],
 
     "readable-stream": ["readable-stream@3.6.2", "", { "dependencies": { "inherits": "^2.0.3", "string_decoder": "^1.1.1", "util-deprecate": "^1.0.1" } }, "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA=="],
 
@@ -420,6 +434,8 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
+
+    "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -465,6 +481,8 @@
 
     "yallist": ["yallist@3.1.1", "", {}, "sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g=="],
 
+    "yaml": ["yaml@2.8.3", "", { "bin": { "yaml": "bin.mjs" } }, "sha512-AvbaCLOO2Otw/lW5bmh9d/WEdcDFdQp2Z2ZUH3pX9U2ihyUY0nvLv7J6TrWowklRGPYbB/IuIMfYgxaCPg5Bpg=="],
+
     "@esbuild-kit/core-utils/esbuild": ["esbuild@0.18.20", "", { "optionalDependencies": { "@esbuild/android-arm": "0.18.20", "@esbuild/android-arm64": "0.18.20", "@esbuild/android-x64": "0.18.20", "@esbuild/darwin-arm64": "0.18.20", "@esbuild/darwin-x64": "0.18.20", "@esbuild/freebsd-arm64": "0.18.20", "@esbuild/freebsd-x64": "0.18.20", "@esbuild/linux-arm": "0.18.20", "@esbuild/linux-arm64": "0.18.20", "@esbuild/linux-ia32": "0.18.20", "@esbuild/linux-loong64": "0.18.20", "@esbuild/linux-mips64el": "0.18.20", "@esbuild/linux-ppc64": "0.18.20", "@esbuild/linux-riscv64": "0.18.20", "@esbuild/linux-s390x": "0.18.20", "@esbuild/linux-x64": "0.18.20", "@esbuild/netbsd-x64": "0.18.20", "@esbuild/openbsd-x64": "0.18.20", "@esbuild/sunos-x64": "0.18.20", "@esbuild/win32-arm64": "0.18.20", "@esbuild/win32-ia32": "0.18.20", "@esbuild/win32-x64": "0.18.20" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-ceqxoedUrcayh7Y7ZX6NdbbDzGROiyVBgC4PriJThBKSVPWnnFHZAkfI1lJT8QFkOwH4qOS2SJkS4wvpGl8BpA=="],
 
     "@tailwindcss/oxide-wasm32-wasi/@emnapi/core": ["@emnapi/core@1.10.0", "", { "dependencies": { "@emnapi/wasi-threads": "1.2.1", "tslib": "^2.4.0" }, "bundled": true }, "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw=="],
@@ -478,6 +496,8 @@
     "@tailwindcss/oxide-wasm32-wasi/@tybys/wasm-util": ["@tybys/wasm-util@0.10.1", "", { "dependencies": { "tslib": "^2.4.0" }, "bundled": true }, "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg=="],
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
+
+    "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 

--- a/package.json
+++ b/package.json
@@ -10,11 +10,13 @@
     "prod:down": "docker compose down",
     "smoke": "bun test tests/smoke.test.ts",
     "test": "bun run --filter '*' test",
+    "e2e": "playwright test",
     "typecheck": "bun run --filter '*' typecheck",
     "build": "bun run --filter '*' build"
   },
   "devDependencies": {
     "typescript": "^5.6.3",
-    "@types/bun": "^1.1.17"
+    "@types/bun": "^1.1.17",
+    "@playwright/test": "^1.49.0"
   }
 }

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+const PORT = 4173;
+const BASE_URL = `http://localhost:${PORT}`;
+
+export default defineConfig({
+  testDir: './tests/e2e',
+  testMatch: /.*\.spec\.ts/,
+  fullyParallel: false,
+  workers: 1,
+  reporter: 'list',
+  timeout: 60_000,
+  expect: { timeout: 5_000 },
+  use: {
+    baseURL: BASE_URL,
+    trace: 'retain-on-failure',
+  },
+  projects: [
+    { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
+  ],
+  webServer: {
+    // Boots a Postgres container, runs migrations, and serves auth API + Vite dist on PORT.
+    command: `bun run apps/server/src/test-helpers/e2e-server.ts`,
+    url: BASE_URL,
+    timeout: 120_000,
+    reuseExistingServer: false,
+    stdout: 'pipe',
+    stderr: 'pipe',
+    env: { E2E_PORT: String(PORT) },
+  },
+});

--- a/tests/e2e/auth.spec.ts
+++ b/tests/e2e/auth.spec.ts
@@ -1,0 +1,29 @@
+import { test, expect } from '@playwright/test';
+
+test('register → dashboard → logout → log back in → dashboard', async ({ page }) => {
+  // Each Playwright run starts against a freshly-booted, empty DB,
+  // so we can use a fixed email and trust uniqueness.
+  const email = `op+${Date.now()}@example.com`;
+  const password = 'hunter2hunter2';
+
+  // Register
+  await page.goto('/register');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password (8+ characters)').fill(password);
+  await page.getByRole('button', { name: 'Create account' }).click();
+
+  // Lands on the dashboard (the AppShell renders the sidebar and the placeholder).
+  await expect(page.getByTestId('dashboard')).toBeVisible();
+  await expect(page.getByTestId('signed-in-as')).toHaveText(email);
+
+  // Logout returns us to the login page.
+  await page.getByRole('button', { name: 'Log out' }).click();
+  await expect(page).toHaveURL(/\/login$/);
+
+  // Log back in lands on the dashboard.
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password').fill(password);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await expect(page.getByTestId('dashboard')).toBeVisible();
+  await expect(page.getByTestId('signed-in-as')).toHaveText(email);
+});


### PR DESCRIPTION
## Summary
- Email/password auth (Hono): register / login / logout / me, cookie-based sessions stored in a new `session` table (opaque tokens, hashed at rest). First registration in an empty org space auto-creates an org and joins the user to it.
- Drizzle schema: adds `user.password_hash` and a `session` table; `user.org_id` was already present.
- React frontend: `/login`, `/register`, and `/` (dashboard) on top of an `AppShell` with a sidebar skeleton + logout. Auth context fetches `/api/auth/me` and gates the dashboard.
- Static-route SPA fallback fixed: visiting `/login` or `/register` now returns `index.html` instead of 404, so client-side routing works on direct navigation.

## Test plan
- [x] `bun run typecheck` — both workspaces clean
- [x] `bun run --filter @nexus/web build` — web builds
- [x] `bun test apps/server/src/routes/auth.test.ts` — 5 integration tests, real Postgres in a docker container, no mocks; cover register, login (right + wrong password), logout, `/me`, first-org auto-create, duplicate-email rejection.
- [x] `bun run e2e` — Playwright drives register → dashboard → logout → log back in → dashboard against a self-contained test server (Postgres container + auth API + built `dist`).
- [ ] `bun run smoke` — not re-run here because the dev compose is currently up on the same host (port conflict on 3000); behavior unchanged structurally.

Closes #5