### PR TITLE
Slice 5: Agent CRUD (headless mode only)

### DIFF
--- a/apps/server/drizzle/0003_agent.sql
+++ b/apps/server/drizzle/0003_agent.sql
@@ -1,0 +1,18 @@
+CREATE TYPE "public"."runtime_mode" AS ENUM('headless', 'dedicated');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "agent" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"name" text NOT NULL,
+	"persona" text NOT NULL,
+	"model" text NOT NULL,
+	"runtime_mode" "runtime_mode" DEFAULT 'headless' NOT NULL,
+	"voice_enabled" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent" ADD CONSTRAINT "agent_org_id_org_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."org"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;

--- a/apps/server/drizzle/meta/0003_snapshot.json
+++ b/apps/server/drizzle/meta/0003_snapshot.json
@@ -1,0 +1,416 @@
+{
+  "id": "1541c9d8-ce78-456a-9066-3217ec89cb6a",
+  "prevId": "5d348c80-08a0-4bed-9297-52e26015b346",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.agent": {
+      "name": "agent",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "persona": {
+          "name": "persona",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "runtime_mode": {
+          "name": "runtime_mode",
+          "type": "runtime_mode",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'headless'"
+        },
+        "voice_enabled": {
+          "name": "voice_enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_org_id_org_id_fk": {
+          "name": "agent_org_id_org_id_fk",
+          "tableFrom": "agent",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.credential": {
+      "name": "credential",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "bytea",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "credential_org_provider_name_unique": {
+          "name": "credential_org_provider_name_unique",
+          "columns": [
+            {
+              "expression": "org_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "credential_org_id_org_id_fk": {
+          "name": "credential_org_id_org_id_fk",
+          "tableFrom": "credential",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.health": {
+      "name": "health",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "ok": {
+          "name": "ok",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "booted_at": {
+          "name": "booted_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.org": {
+      "name": "org",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": [
+            "user_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_hash_unique": {
+          "name": "session_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "token_hash"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "org_id": {
+          "name": "org_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "password_hash": {
+          "name": "password_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_org_id_org_id_fk": {
+          "name": "user_org_id_org_id_fk",
+          "tableFrom": "user",
+          "tableTo": "org",
+          "columnsFrom": [
+            "org_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": [
+            "email"
+          ]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.runtime_mode": {
+      "name": "runtime_mode",
+      "schema": "public",
+      "values": [
+        "headless",
+        "dedicated"
+      ]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -22,6 +22,13 @@
       "when": 1777467011115,
       "tag": "0002_auth",
       "breakpoints": true
+    },
+    {
+      "idx": 3,
+      "version": "7",
+      "when": 1777468291634,
+      "tag": "0003_agent",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -1,4 +1,15 @@
-import { pgTable, uuid, text, timestamp, boolean, customType, uniqueIndex } from 'drizzle-orm/pg-core';
+import {
+  pgTable,
+  uuid,
+  text,
+  timestamp,
+  boolean,
+  customType,
+  uniqueIndex,
+  pgEnum,
+} from 'drizzle-orm/pg-core';
+
+export const runtimeMode = pgEnum('runtime_mode', ['headless', 'dedicated']);
 
 const bytea = customType<{ data: Buffer; default: false }>({
   dataType() {
@@ -36,6 +47,20 @@ export const health = pgTable('health', {
   id: uuid('id').primaryKey().defaultRandom(),
   ok: boolean('ok').notNull().default(true),
   bootedAt: timestamp('booted_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+export const agent = pgTable('agent', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id')
+    .notNull()
+    .references(() => org.id, { onDelete: 'cascade' }),
+  name: text('name').notNull(),
+  persona: text('persona').notNull(),
+  model: text('model').notNull(),
+  runtimeMode: runtimeMode('runtime_mode').notNull().default('headless'),
+  voiceEnabled: boolean('voice_enabled').notNull().default(false),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 });
 
 export const credential = pgTable(

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -8,6 +8,7 @@ import { healthRoute } from './routes/health.ts';
 import { mountStatic } from './routes/static.ts';
 import { createCredentialService } from './credentials/service.ts';
 import { authRoute } from './routes/auth.ts';
+import { agentsRoute } from './routes/agents.ts';
 
 const env = loadEnv();
 
@@ -24,6 +25,7 @@ const app = new Hono();
 app.use('*', requestLogger({ logger: log }));
 app.route('/healthz', healthRoute({ env, db }));
 app.route('/api/auth', authRoute({ db }));
+app.route('/api/agents', agentsRoute({ db }));
 mountStatic(app);
 
 const server = Bun.serve({

--- a/apps/server/src/routes/agents.test.ts
+++ b/apps/server/src/routes/agents.test.ts
@@ -1,0 +1,212 @@
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { authRoute } from './auth.ts';
+import { agentsRoute } from './agents.ts';
+
+let pg: StartedPg;
+let app: Hono;
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+
+  app = new Hono();
+  const db = getDb(pg.url);
+  app.route('/api/auth', authRoute({ db }));
+  app.route('/api/agents', agentsRoute({ db }));
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(sql`TRUNCATE TABLE "agent", "session", "user", "org" RESTART IDENTITY CASCADE`);
+});
+
+async function registerAndCookie(email: string): Promise<string> {
+  const res = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password: 'hunter2hunter2' }),
+  });
+  if (res.status !== 201) {
+    throw new Error(`register failed: ${res.status} ${await res.text()}`);
+  }
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  const match = /nexus_session=[^;]+/.exec(setCookie);
+  if (!match) throw new Error('no session cookie set');
+  return match[0];
+}
+
+test('unauthenticated requests are rejected with 401', async () => {
+  const res = await app.request('/api/agents', { method: 'GET' });
+  expect(res.status).toBe(401);
+});
+
+test('create agent → list returns it scoped to operator org', async () => {
+  const cookie = await registerAndCookie('op@example.com');
+
+  const create = await app.request('/api/agents', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({
+      name: 'Sales Bot',
+      persona: 'Friendly sales rep who answers product questions.',
+      model: 'gpt-4o-mini',
+      voiceEnabled: false,
+    }),
+  });
+  expect(create.status).toBe(201);
+  const created = (await create.json()) as {
+    agent: {
+      id: string;
+      name: string;
+      persona: string;
+      model: string;
+      runtimeMode: string;
+      voiceEnabled: boolean;
+    };
+  };
+  expect(created.agent.name).toBe('Sales Bot');
+  expect(created.agent.runtimeMode).toBe('headless');
+  expect(created.agent.voiceEnabled).toBe(false);
+  expect(created.agent.id).toMatch(/^[0-9a-f-]{36}$/);
+
+  const list = await app.request('/api/agents', { headers: { cookie } });
+  expect(list.status).toBe(200);
+  const body = (await list.json()) as { agents: Array<{ id: string; name: string }> };
+  expect(body.agents).toHaveLength(1);
+  expect(body.agents[0]!.id).toBe(created.agent.id);
+});
+
+test('create rejects bad payload with 400', async () => {
+  const cookie = await registerAndCookie('op@example.com');
+  const res = await app.request('/api/agents', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({ name: '' }),
+  });
+  expect(res.status).toBe(400);
+});
+
+test('list is org-scoped: another org cannot see this org agents', async () => {
+  // First op creates an agent.
+  const cookieA = await registerAndCookie('opA@example.com');
+  await app.request('/api/agents', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie: cookieA },
+    body: JSON.stringify({
+      name: 'Alpha',
+      persona: 'Persona A',
+      model: 'gpt-4o-mini',
+      voiceEnabled: false,
+    }),
+  });
+
+  // Wipe everything so the next "first" registration creates a fresh org.
+  const db = getDb(pg.url);
+  await db.execute(sql`TRUNCATE TABLE "session", "user", "org" RESTART IDENTITY CASCADE`);
+
+  const cookieB = await registerAndCookie('opB@example.com');
+  const list = await app.request('/api/agents', { headers: { cookie: cookieB } });
+  expect(list.status).toBe(200);
+  const body = (await list.json()) as { agents: unknown[] };
+  expect(body.agents).toEqual([]);
+});
+
+test('update agent persists persona, model, and voice toggle', async () => {
+  const cookie = await registerAndCookie('op@example.com');
+  const create = await app.request('/api/agents', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({
+      name: 'Sales Bot',
+      persona: 'old persona',
+      model: 'gpt-4o-mini',
+      voiceEnabled: false,
+    }),
+  });
+  const { agent } = (await create.json()) as { agent: { id: string } };
+
+  const upd = await app.request(`/api/agents/${agent.id}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({
+      name: 'Sales Bot v2',
+      persona: 'new persona',
+      model: 'gpt-4o',
+      voiceEnabled: true,
+    }),
+  });
+  expect(upd.status).toBe(200);
+  const updated = (await upd.json()) as {
+    agent: { name: string; persona: string; model: string; voiceEnabled: boolean };
+  };
+  expect(updated.agent.name).toBe('Sales Bot v2');
+  expect(updated.agent.persona).toBe('new persona');
+  expect(updated.agent.model).toBe('gpt-4o');
+  expect(updated.agent.voiceEnabled).toBe(true);
+});
+
+test('delete removes the agent', async () => {
+  const cookie = await registerAndCookie('op@example.com');
+  const create = await app.request('/api/agents', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({
+      name: 'Throwaway',
+      persona: 'persona',
+      model: 'gpt-4o-mini',
+      voiceEnabled: false,
+    }),
+  });
+  const { agent } = (await create.json()) as { agent: { id: string } };
+
+  const del = await app.request(`/api/agents/${agent.id}`, {
+    method: 'DELETE',
+    headers: { cookie },
+  });
+  expect(del.status).toBe(204);
+
+  const list = await app.request('/api/agents', { headers: { cookie } });
+  const body = (await list.json()) as { agents: unknown[] };
+  expect(body.agents).toEqual([]);
+});
+
+test('update / delete on another org returns 404', async () => {
+  const cookieA = await registerAndCookie('opA@example.com');
+  const create = await app.request('/api/agents', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie: cookieA },
+    body: JSON.stringify({
+      name: 'Alpha',
+      persona: 'pa',
+      model: 'gpt-4o-mini',
+      voiceEnabled: false,
+    }),
+  });
+  const { agent } = (await create.json()) as { agent: { id: string } };
+
+  const db = getDb(pg.url);
+  await db.execute(sql`TRUNCATE TABLE "session", "user", "org" RESTART IDENTITY CASCADE`);
+
+  const cookieB = await registerAndCookie('opB@example.com');
+  const upd = await app.request(`/api/agents/${agent.id}`, {
+    method: 'PATCH',
+    headers: { 'content-type': 'application/json', cookie: cookieB },
+    body: JSON.stringify({ name: 'X', persona: 'p', model: 'gpt-4o-mini', voiceEnabled: false }),
+  });
+  expect(upd.status).toBe(404);
+
+  const del = await app.request(`/api/agents/${agent.id}`, {
+    method: 'DELETE',
+    headers: { cookie: cookieB },
+  });
+  expect(del.status).toBe(404);
+});

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -1,0 +1,119 @@
+import { Hono, type Context } from 'hono';
+import { getCookie } from 'hono/cookie';
+import * as v from 'valibot';
+import { and, eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { agent, session, user } from '../db/schema.ts';
+
+const SESSION_COOKIE = 'nexus_session';
+
+// Headless is the only mode the UI exposes at this slice. The schema accepts
+// `dedicated` so a later slice can flip it on without a migration.
+const AgentInput = v.object({
+  name: v.pipe(v.string(), v.minLength(1), v.maxLength(120)),
+  persona: v.pipe(v.string(), v.minLength(1), v.maxLength(8_000)),
+  model: v.pipe(v.string(), v.minLength(1), v.maxLength(120)),
+  voiceEnabled: v.boolean(),
+});
+
+type AgentRow = typeof agent.$inferSelect;
+
+type Deps = { db: PostgresJsDatabase };
+
+export function agentsRoute({ db }: Deps) {
+  const router = new Hono();
+
+  router.get('/', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const rows = await db.select().from(agent).where(eq(agent.orgId, orgId));
+    return c.json({ agents: rows.map(toApi) }, 200);
+  });
+
+  router.post('/', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const json = await safeJson(c.req.raw);
+    const parsed = v.safeParse(AgentInput, json);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_agent_shape' }, 400);
+    }
+    const { name, persona, model, voiceEnabled } = parsed.output;
+    const [created] = await db
+      .insert(agent)
+      .values({ orgId, name, persona, model, voiceEnabled })
+      .returning();
+    return c.json({ agent: toApi(created!) }, 201);
+  });
+
+  router.patch('/:id', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const id = c.req.param('id');
+    const json = await safeJson(c.req.raw);
+    const parsed = v.safeParse(AgentInput, json);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_agent_shape' }, 400);
+    }
+    const { name, persona, model, voiceEnabled } = parsed.output;
+    const [updated] = await db
+      .update(agent)
+      .set({ name, persona, model, voiceEnabled, updatedAt: new Date() })
+      .where(and(eq(agent.id, id), eq(agent.orgId, orgId)))
+      .returning();
+    if (!updated) return c.json({ error: 'not_found' }, 404);
+    return c.json({ agent: toApi(updated) }, 200);
+  });
+
+  router.delete('/:id', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const id = c.req.param('id');
+    const deleted = await db
+      .delete(agent)
+      .where(and(eq(agent.id, id), eq(agent.orgId, orgId)))
+      .returning({ id: agent.id });
+    if (deleted.length === 0) return c.json({ error: 'not_found' }, 404);
+    return c.body(null, 204);
+  });
+
+  return router;
+}
+
+function toApi(row: AgentRow) {
+  return {
+    id: row.id,
+    name: row.name,
+    persona: row.persona,
+    model: row.model,
+    runtimeMode: row.runtimeMode,
+    voiceEnabled: row.voiceEnabled,
+  };
+}
+
+async function resolveOrgId(c: Context, db: PostgresJsDatabase): Promise<string | null> {
+  const token = getCookie(c, SESSION_COOKIE);
+  if (!token) return null;
+  const [row] = await db
+    .select({ orgId: user.orgId, expiresAt: session.expiresAt })
+    .from(session)
+    .innerJoin(user, eq(session.userId, user.id))
+    .where(eq(session.tokenHash, hashToken(token)))
+    .limit(1);
+  if (!row || row.expiresAt.getTime() < Date.now()) return null;
+  return row.orgId;
+}
+
+function hashToken(token: string): string {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(token);
+  return hasher.digest('hex');
+}
+
+async function safeJson(req: Request): Promise<unknown> {
+  try {
+    return await req.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/server/src/test-helpers/e2e-server.ts
+++ b/apps/server/src/test-helpers/e2e-server.ts
@@ -10,6 +10,7 @@ import { Hono } from 'hono';
 import { startPg } from './pg-container.ts';
 import { runMigrations, getDb, closeDb } from '../db/client.ts';
 import { authRoute } from '../routes/auth.ts';
+import { agentsRoute } from '../routes/agents.ts';
 import { mountStatic } from '../routes/static.ts';
 
 const port = Number.parseInt(process.env.E2E_PORT ?? '4173', 10);
@@ -22,6 +23,7 @@ const app = new Hono();
 const db = getDb(pg.url);
 
 app.route('/api/auth', authRoute({ db }));
+app.route('/api/agents', agentsRoute({ db }));
 mountStatic(app);
 
 const server = Bun.serve({ port, fetch: app.fetch });

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -1,6 +1,7 @@
 import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router-dom';
 import { AuthProvider, useAuth } from './auth/auth';
 import { AppShell } from './layout/AppShell';
+import { Agents } from './pages/Agents';
 import { Dashboard } from './pages/Dashboard';
 import { Login } from './pages/Login';
 import { Register } from './pages/Register';
@@ -15,6 +16,7 @@ export function App() {
           <Route element={<RequireAuth />}>
             <Route element={<AppShell />}>
               <Route index element={<Dashboard />} />
+              <Route path="/agents" element={<Agents />} />
             </Route>
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -11,6 +11,7 @@ export function AppShell() {
         <div className="px-2 py-1 text-lg font-semibold tracking-tight">Nexus</div>
         <nav className="mt-4 space-y-1 text-sm">
           <SideLink to="/" label="Dashboard" />
+          <SideLink to="/agents" label="Agents" />
         </nav>
         <div className="mt-auto pt-4 border-t border-zinc-800 text-xs text-zinc-400">
           <div data-testid="signed-in-as" className="px-2 truncate">

--- a/apps/web/src/pages/Agents.tsx
+++ b/apps/web/src/pages/Agents.tsx
@@ -192,7 +192,7 @@ export function Agents() {
               disabled={submitting}
               className="rounded-md bg-emerald-500 px-3 py-1.5 text-sm font-medium text-zinc-950 hover:bg-emerald-400 disabled:opacity-60"
             >
-              {submitting ? 'Saving…' : editingId ? 'Save changes' : 'Create agent'}
+              {submitLabel(submitting, editingId !== null)}
             </button>
             <button
               type="button"
@@ -205,46 +205,12 @@ export function Agents() {
         </form>
       )}
 
-      {loading ? (
-        <p className="text-zinc-400 text-sm">Loading…</p>
-      ) : agents.length === 0 ? (
-        <p data-testid="agents-empty" className="text-zinc-400 text-sm">
-          No agents yet. Create one to get started.
-        </p>
-      ) : (
-        <ul data-testid="agents-list" className="divide-y divide-zinc-800 rounded-lg border border-zinc-800">
-          {agents.map((a) => (
-            <li
-              key={a.id}
-              data-testid={`agent-row-${a.id}`}
-              className="flex items-center justify-between px-4 py-3"
-            >
-              <div className="min-w-0">
-                <div className="font-medium text-zinc-100">{a.name}</div>
-                <div className="truncate text-xs text-zinc-400">
-                  {a.model} · voice {a.voiceEnabled ? 'on' : 'off'}
-                </div>
-              </div>
-              <div className="flex gap-2">
-                <button
-                  type="button"
-                  onClick={() => startEdit(a)}
-                  className="rounded-md border border-zinc-700 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
-                >
-                  Edit
-                </button>
-                <button
-                  type="button"
-                  onClick={() => setPendingDelete({ id: a.id, name: a.name })}
-                  className="rounded-md border border-red-700/60 px-2 py-1 text-xs text-red-300 hover:bg-red-900/30"
-                >
-                  Delete
-                </button>
-              </div>
-            </li>
-          ))}
-        </ul>
-      )}
+      <AgentList
+        loading={loading}
+        agents={agents}
+        onEdit={startEdit}
+        onDelete={(a) => setPendingDelete({ id: a.id, name: a.name })}
+      />
 
       {pendingDelete && (
         <div
@@ -280,6 +246,69 @@ export function Agents() {
       )}
     </section>
   );
+}
+
+function AgentList({
+  loading,
+  agents,
+  onEdit,
+  onDelete,
+}: {
+  loading: boolean;
+  agents: Agent[];
+  onEdit: (a: Agent) => void;
+  onDelete: (a: Agent) => void;
+}) {
+  if (loading) {
+    return <p className="text-zinc-400 text-sm">Loading…</p>;
+  }
+  if (agents.length === 0) {
+    return (
+      <p data-testid="agents-empty" className="text-zinc-400 text-sm">
+        No agents yet. Create one to get started.
+      </p>
+    );
+  }
+  return (
+    <ul data-testid="agents-list" className="divide-y divide-zinc-800 rounded-lg border border-zinc-800">
+      {agents.map((a) => (
+        <li
+          key={a.id}
+          data-testid={`agent-row-${a.id}`}
+          className="flex items-center justify-between px-4 py-3"
+        >
+          <div className="min-w-0">
+            <div className="font-medium text-zinc-100">{a.name}</div>
+            <div className="truncate text-xs text-zinc-400">
+              {a.model} · voice {a.voiceEnabled ? 'on' : 'off'}
+            </div>
+          </div>
+          <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => onEdit(a)}
+              className="rounded-md border border-zinc-700 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+            >
+              Edit
+            </button>
+            <button
+              type="button"
+              onClick={() => onDelete(a)}
+              className="rounded-md border border-red-700/60 px-2 py-1 text-xs text-red-300 hover:bg-red-900/30"
+            >
+              Delete
+            </button>
+          </div>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+function submitLabel(submitting: boolean, editing: boolean): string {
+  if (submitting) return 'Saving…';
+  if (editing) return 'Save changes';
+  return 'Create agent';
 }
 
 function TextField({

--- a/apps/web/src/pages/Agents.tsx
+++ b/apps/web/src/pages/Agents.tsx
@@ -1,0 +1,333 @@
+import { useCallback, useEffect, useState, type FormEvent } from 'react';
+
+export type Agent = {
+  id: string;
+  name: string;
+  persona: string;
+  model: string;
+  runtimeMode: 'headless' | 'dedicated';
+  voiceEnabled: boolean;
+};
+
+type FormDraft = {
+  name: string;
+  persona: string;
+  model: string;
+  voiceEnabled: boolean;
+};
+
+const EMPTY_DRAFT: FormDraft = {
+  name: '',
+  persona: '',
+  model: 'gpt-4o-mini',
+  voiceEnabled: false,
+};
+
+type DeleteTarget = { id: string; name: string };
+
+export function Agents() {
+  const [agents, setAgents] = useState<Agent[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [draft, setDraft] = useState<FormDraft>(EMPTY_DRAFT);
+  const [submitting, setSubmitting] = useState(false);
+  const [pendingDelete, setPendingDelete] = useState<DeleteTarget | null>(null);
+
+  const refresh = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/agents', { credentials: 'same-origin' });
+      if (!res.ok) throw new Error(`Failed to load agents (${res.status})`);
+      const body = (await res.json()) as { agents: Agent[] };
+      setAgents(body.agents);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load agents.');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+  }, [refresh]);
+
+  function startCreate() {
+    setEditingId(null);
+    setDraft(EMPTY_DRAFT);
+    setCreating(true);
+  }
+
+  function startEdit(a: Agent) {
+    setCreating(false);
+    setEditingId(a.id);
+    setDraft({
+      name: a.name,
+      persona: a.persona,
+      model: a.model,
+      voiceEnabled: a.voiceEnabled,
+    });
+  }
+
+  function cancelForm() {
+    setCreating(false);
+    setEditingId(null);
+    setDraft(EMPTY_DRAFT);
+  }
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const url = editingId ? `/api/agents/${editingId}` : '/api/agents';
+      const method = editingId ? 'PATCH' : 'POST';
+      const res = await fetch(url, {
+        method,
+        headers: { 'content-type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify(draft),
+      });
+      if (!res.ok) throw new Error(`Save failed (${res.status})`);
+      await refresh();
+      cancelForm();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function confirmDelete() {
+    if (!pendingDelete) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/agents/${pendingDelete.id}`, {
+        method: 'DELETE',
+        credentials: 'same-origin',
+      });
+      if (!res.ok && res.status !== 204) {
+        throw new Error(`Delete failed (${res.status})`);
+      }
+      await refresh();
+      setPendingDelete(null);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Delete failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  const formOpen = creating || editingId !== null;
+
+  return (
+    <section data-testid="agents-page" className="space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold tracking-tight">Agents</h1>
+        {!formOpen && (
+          <button
+            type="button"
+            onClick={startCreate}
+            className="rounded-md bg-emerald-500 px-3 py-1.5 text-sm font-medium text-zinc-950 hover:bg-emerald-400"
+          >
+            New agent
+          </button>
+        )}
+      </header>
+
+      {error && (
+        <p role="alert" className="text-sm text-red-400">
+          {error}
+        </p>
+      )}
+
+      {formOpen && (
+        <form
+          data-testid="agent-form"
+          onSubmit={onSubmit}
+          className="space-y-3 rounded-lg border border-zinc-800 bg-zinc-900/50 p-4"
+        >
+          <h2 className="text-lg font-semibold">
+            {editingId ? 'Edit agent' : 'New agent'}
+          </h2>
+          <TextField
+            label="Name"
+            value={draft.name}
+            onChange={(name) => setDraft((d) => ({ ...d, name }))}
+            required
+          />
+          <TextAreaField
+            label="Persona"
+            value={draft.persona}
+            onChange={(persona) => setDraft((d) => ({ ...d, persona }))}
+            required
+          />
+          <TextField
+            label="Model"
+            value={draft.model}
+            onChange={(model) => setDraft((d) => ({ ...d, model }))}
+            required
+          />
+          <div className="text-sm text-zinc-400">
+            Runtime mode: <span className="text-zinc-200">headless</span>
+            <span className="ml-2 text-xs text-zinc-500">
+              (dedicated mode lands in a later release)
+            </span>
+          </div>
+          <label className="flex items-center gap-2 text-sm text-zinc-200">
+            <input
+              type="checkbox"
+              data-testid="voice-enabled"
+              checked={draft.voiceEnabled}
+              onChange={(e) => setDraft((d) => ({ ...d, voiceEnabled: e.target.checked }))}
+            />
+            Voice enabled
+          </label>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              disabled={submitting}
+              className="rounded-md bg-emerald-500 px-3 py-1.5 text-sm font-medium text-zinc-950 hover:bg-emerald-400 disabled:opacity-60"
+            >
+              {submitting ? 'Saving…' : editingId ? 'Save changes' : 'Create agent'}
+            </button>
+            <button
+              type="button"
+              onClick={cancelForm}
+              className="rounded-md border border-zinc-700 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-800"
+            >
+              Cancel
+            </button>
+          </div>
+        </form>
+      )}
+
+      {loading ? (
+        <p className="text-zinc-400 text-sm">Loading…</p>
+      ) : agents.length === 0 ? (
+        <p data-testid="agents-empty" className="text-zinc-400 text-sm">
+          No agents yet. Create one to get started.
+        </p>
+      ) : (
+        <ul data-testid="agents-list" className="divide-y divide-zinc-800 rounded-lg border border-zinc-800">
+          {agents.map((a) => (
+            <li
+              key={a.id}
+              data-testid={`agent-row-${a.id}`}
+              className="flex items-center justify-between px-4 py-3"
+            >
+              <div className="min-w-0">
+                <div className="font-medium text-zinc-100">{a.name}</div>
+                <div className="truncate text-xs text-zinc-400">
+                  {a.model} · voice {a.voiceEnabled ? 'on' : 'off'}
+                </div>
+              </div>
+              <div className="flex gap-2">
+                <button
+                  type="button"
+                  onClick={() => startEdit(a)}
+                  className="rounded-md border border-zinc-700 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+                >
+                  Edit
+                </button>
+                <button
+                  type="button"
+                  onClick={() => setPendingDelete({ id: a.id, name: a.name })}
+                  className="rounded-md border border-red-700/60 px-2 py-1 text-xs text-red-300 hover:bg-red-900/30"
+                >
+                  Delete
+                </button>
+              </div>
+            </li>
+          ))}
+        </ul>
+      )}
+
+      {pendingDelete && (
+        <div
+          data-testid="delete-confirm"
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-10 flex items-center justify-center bg-black/60 p-4"
+        >
+          <div className="w-full max-w-sm space-y-4 rounded-lg border border-zinc-800 bg-zinc-900 p-5">
+            <h2 className="text-lg font-semibold">Delete agent?</h2>
+            <p className="text-sm text-zinc-300">
+              This permanently removes <span className="text-zinc-100">{pendingDelete.name}</span>.
+            </p>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                onClick={() => setPendingDelete(null)}
+                className="rounded-md border border-zinc-700 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-800"
+              >
+                Cancel
+              </button>
+              <button
+                type="button"
+                onClick={() => void confirmDelete()}
+                disabled={submitting}
+                className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-500 disabled:opacity-60"
+              >
+                {submitting ? 'Deleting…' : 'Delete'}
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+function TextField({
+  label,
+  value,
+  onChange,
+  required,
+}: {
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  required?: boolean;
+}) {
+  return (
+    <label className="block text-sm">
+      <span className="block text-zinc-300 mb-1">{label}</span>
+      <input
+        type="text"
+        value={value}
+        required={required}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-zinc-100 outline-none focus:border-emerald-500"
+      />
+    </label>
+  );
+}
+
+function TextAreaField({
+  label,
+  value,
+  onChange,
+  required,
+}: {
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  required?: boolean;
+}) {
+  return (
+    <label className="block text-sm">
+      <span className="block text-zinc-300 mb-1">{label}</span>
+      <textarea
+        value={value}
+        required={required}
+        rows={4}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-zinc-100 outline-none focus:border-emerald-500"
+      />
+    </label>
+  );
+}

--- a/tests/e2e/agents.spec.ts
+++ b/tests/e2e/agents.spec.ts
@@ -1,0 +1,54 @@
+import { test, expect } from '@playwright/test';
+
+test('agent CRUD: create → list → edit → delete', async ({ page }) => {
+  // Each Playwright run boots a fresh DB so a fixed email is fine.
+  const email = `op+agents+${Date.now()}@example.com`;
+  const password = 'hunter2hunter2';
+
+  // Register and land on dashboard.
+  await page.goto('/register');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password (8+ characters)').fill(password);
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page.getByTestId('dashboard')).toBeVisible();
+
+  // Navigate to Agents.
+  await page.getByRole('link', { name: 'Agents' }).click();
+  await expect(page.getByTestId('agents-page')).toBeVisible();
+  await expect(page.getByTestId('agents-empty')).toBeVisible();
+
+  // Create.
+  await page.getByRole('button', { name: 'New agent' }).click();
+  await page.getByLabel('Name').fill('Sales Bot');
+  await page.getByLabel('Persona').fill('Friendly sales rep.');
+  await page.getByLabel('Model').fill('gpt-4o-mini');
+  await page.getByRole('button', { name: 'Create agent' }).click();
+
+  // Appears in the list.
+  const list = page.getByTestId('agents-list');
+  await expect(list).toBeVisible();
+  await expect(list.getByText('Sales Bot')).toBeVisible();
+  await expect(list.getByText('voice off')).toBeVisible();
+
+  // Edit: change persona + model + flip voice on.
+  await list.getByRole('button', { name: 'Edit' }).click();
+  await page.getByLabel('Persona').fill('Enthusiastic sales rep.');
+  await page.getByLabel('Model').fill('gpt-4o');
+  await page.getByTestId('voice-enabled').check();
+  await page.getByRole('button', { name: 'Save changes' }).click();
+
+  // Change persists: list shows new model + voice on.
+  await expect(list.getByText('gpt-4o · voice on')).toBeVisible();
+
+  // Reload and re-confirm to prove it's persisted, not just optimistic UI.
+  await page.reload();
+  await expect(page.getByTestId('agents-list').getByText('gpt-4o · voice on')).toBeVisible();
+
+  // Delete via confirmation dialog.
+  await page.getByTestId('agents-list').getByRole('button', { name: 'Delete' }).click();
+  await expect(page.getByTestId('delete-confirm')).toBeVisible();
+  await page.getByTestId('delete-confirm').getByRole('button', { name: 'Delete' }).click();
+
+  // Removed.
+  await expect(page.getByTestId('agents-empty')).toBeVisible();
+});


### PR DESCRIPTION
## Summary
- Drizzle `agent` schema (id, org_id, name, persona, model, runtime_mode enum {headless, dedicated}, voice_enabled) and migration `0003_agent.sql`.
- Hono CRUD endpoints under `/api/agents`, org-scoped via the session cookie, with Valibot validation on every body.
- React Agents page: list, create form, edit form (headless-only label in UI), delete confirmation dialog. Sidebar nav link added.
- Playwright e2e: register → create → list → edit → reload (persistence) → delete → empty.

The runtime_mode enum carries both values so #21 can flip on `dedicated` without a migration. Voice channel itself lands in #13; this slice only exposes the toggle.

## Test plan
- [x] `bun run typecheck` (workspace)
- [x] `bun test` in `apps/server` — 21 passing (5 auth, 7 agents, 9 others)
- [x] `bunx playwright test` — 2 passing (agents + auth)

Closes #6