### PR TITLE
Slice 6: Web widget channel + first end-to-end

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,6 @@ playwright-report/
 # Local Claude state (per-machine, not shared)
 .claude/settings.local.json
 .claude/.cache/
+
+# Headless runtime materialization root (per-session SDK working dirs)
+.nexus-runtime/

--- a/apps/server/drizzle/0004_widget_channel.sql
+++ b/apps/server/drizzle/0004_widget_channel.sql
@@ -1,0 +1,100 @@
+CREATE TYPE "public"."channel_kind" AS ENUM('widget', 'sms', 'voice', 'email', 'telegram', 'whatsapp');--> statement-breakpoint
+CREATE TYPE "public"."identifier_kind" AS ENUM('widget_session_id', 'phone', 'email', 'telegram_user_id', 'whatsapp_user_id');--> statement-breakpoint
+CREATE TYPE "public"."message_role" AS ENUM('user', 'assistant', 'system');--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "channel" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"kind" "channel_kind" NOT NULL,
+	"agent_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "contact" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"do_not_contact" boolean DEFAULT false NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "identifier" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"contact_id" uuid NOT NULL,
+	"kind" "identifier_kind" NOT NULL,
+	"value" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "agent_session" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"org_id" uuid NOT NULL,
+	"agent_id" uuid NOT NULL,
+	"channel_id" uuid NOT NULL,
+	"contact_id" uuid NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "agent_message" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"session_id" uuid NOT NULL,
+	"sequence" integer NOT NULL,
+	"role" "message_role" NOT NULL,
+	"content" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "channel" ADD CONSTRAINT "channel_org_id_org_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."org"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "channel" ADD CONSTRAINT "channel_agent_id_agent_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agent"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "contact" ADD CONSTRAINT "contact_org_id_org_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."org"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "identifier" ADD CONSTRAINT "identifier_contact_id_contact_id_fk" FOREIGN KEY ("contact_id") REFERENCES "public"."contact"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent_session" ADD CONSTRAINT "agent_session_org_id_org_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."org"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent_session" ADD CONSTRAINT "agent_session_agent_id_agent_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agent"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent_session" ADD CONSTRAINT "agent_session_channel_id_channel_id_fk" FOREIGN KEY ("channel_id") REFERENCES "public"."channel"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent_session" ADD CONSTRAINT "agent_session_contact_id_contact_id_fk" FOREIGN KEY ("contact_id") REFERENCES "public"."contact"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "agent_message" ADD CONSTRAINT "agent_message_session_id_agent_session_id_fk" FOREIGN KEY ("session_id") REFERENCES "public"."agent_session"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "identifier_kind_value_unique" ON "identifier" USING btree ("kind","value");--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "agent_message_session_sequence_unique" ON "agent_message" USING btree ("session_id","sequence");

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -29,6 +29,13 @@
       "when": 1777468291634,
       "tag": "0003_agent",
       "breakpoints": true
+    },
+    {
+      "idx": 4,
+      "version": "7",
+      "when": 1777500000000,
+      "tag": "0004_widget_channel",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -7,9 +7,31 @@ import {
   customType,
   uniqueIndex,
   pgEnum,
+  integer,
 } from 'drizzle-orm/pg-core';
 
 export const runtimeMode = pgEnum('runtime_mode', ['headless', 'dedicated']);
+
+// Channel kinds the platform plans to support; only `widget` is wired in this slice.
+export const channelKind = pgEnum('channel_kind', [
+  'widget',
+  'sms',
+  'voice',
+  'email',
+  'telegram',
+  'whatsapp',
+]);
+
+// Identifier kinds. The widget uses `widget_session_id`; later channels add the rest.
+export const identifierKind = pgEnum('identifier_kind', [
+  'widget_session_id',
+  'phone',
+  'email',
+  'telegram_user_id',
+  'whatsapp_user_id',
+]);
+
+export const messageRole = pgEnum('message_role', ['user', 'assistant', 'system']);
 
 const bytea = customType<{ data: Buffer; default: false }>({
   dataType() {
@@ -62,6 +84,94 @@ export const agent = pgTable('agent', {
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   updatedAt: timestamp('updated_at', { withTimezone: true }).notNull().defaultNow(),
 });
+
+// Channel: an addressable surface (one row per agent×channel binding). For the
+// widget, every agent installation has its own channel row; later channels
+// (SMS, voice, etc.) follow the same pattern.
+export const channel = pgTable('channel', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id')
+    .notNull()
+    .references(() => org.id, { onDelete: 'cascade' }),
+  kind: channelKind('kind').notNull(),
+  agentId: uuid('agent_id')
+    .notNull()
+    .references(() => agent.id, { onDelete: 'cascade' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+// Contact: a person/end-user. Identifiers below carry the channel-specific
+// addresses that resolve to a contact. `do_not_contact` is honored by every
+// outbound code path.
+export const contact = pgTable('contact', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id')
+    .notNull()
+    .references(() => org.id, { onDelete: 'cascade' }),
+  doNotContact: boolean('do_not_contact').notNull().default(false),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+// Identifier: a typed handle for a contact (phone, email, widget session id…).
+// Unique on (kind, value) so the same handle can't point at two contacts.
+export const identifier = pgTable(
+  'identifier',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    contactId: uuid('contact_id')
+      .notNull()
+      .references(() => contact.id, { onDelete: 'cascade' }),
+    kind: identifierKind('kind').notNull(),
+    value: text('value').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    kindValueUnique: uniqueIndex('identifier_kind_value_unique').on(t.kind, t.value),
+  }),
+);
+
+// Agent conversation session: one ongoing thread between a contact and an
+// agent on a particular channel. Named `agent_session` because the existing
+// `session` table holds operator HTTP sessions.
+export const agentSession = pgTable('agent_session', {
+  id: uuid('id').primaryKey().defaultRandom(),
+  orgId: uuid('org_id')
+    .notNull()
+    .references(() => org.id, { onDelete: 'cascade' }),
+  agentId: uuid('agent_id')
+    .notNull()
+    .references(() => agent.id, { onDelete: 'cascade' }),
+  channelId: uuid('channel_id')
+    .notNull()
+    .references(() => channel.id, { onDelete: 'cascade' }),
+  contactId: uuid('contact_id')
+    .notNull()
+    .references(() => contact.id, { onDelete: 'cascade' }),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+});
+
+// Agent message: append-only log of turns within a session. PRD invariant #5
+// requires monotonic, gap-free sequence numbers — enforced in session-store.ts
+// and pinned by a unique index on (session, sequence).
+export const agentMessage = pgTable(
+  'agent_message',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    sessionId: uuid('session_id')
+      .notNull()
+      .references(() => agentSession.id, { onDelete: 'cascade' }),
+    sequence: integer('sequence').notNull(),
+    role: messageRole('role').notNull(),
+    content: text('content').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    sessionSequenceUnique: uniqueIndex('agent_message_session_sequence_unique').on(
+      t.sessionId,
+      t.sequence,
+    ),
+  }),
+);
 
 export const credential = pgTable(
   'credential',

--- a/apps/server/src/headless/materialize.test.ts
+++ b/apps/server/src/headless/materialize.test.ts
@@ -1,0 +1,88 @@
+// PRD invariants #1 (real on-disk skill/sub-agent trees per session) and
+// #2 (walkup containment — no SDK-discoverable config in any ancestor).
+//
+// `materializeSession` writes the per-session working directory and refuses
+// to do so if any ancestor of the session root carries an SDK-discoverable
+// config. The SDK walks up looking for .claude/ and .mcp.json, so an ancestor
+// that has either would silently leak settings into the headless run.
+
+import { test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdir, mkdtemp, rm, stat, writeFile, readFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { materializeSession, AncestorSanitationError } from './materialize.ts';
+
+let tmpRoot: string;
+
+beforeEach(async () => {
+  tmpRoot = await mkdtemp(join(tmpdir(), 'nexus-mat-'));
+});
+
+afterEach(async () => {
+  await rm(tmpRoot, { recursive: true, force: true });
+});
+
+test('materialize creates a per-session working directory under the root', async () => {
+  const root = join(tmpRoot, 'sessions');
+  await mkdir(root, { recursive: true });
+  const dir = await materializeSession({
+    sessionRoot: root,
+    sessionId: 'abc',
+    skills: [],
+    subagents: [],
+  });
+  expect(dir.cwd.startsWith(root)).toBe(true);
+  const s = await stat(dir.cwd);
+  expect(s.isDirectory()).toBe(true);
+});
+
+test('materialize writes skills as real files inside the session cwd', async () => {
+  const root = join(tmpRoot, 'sessions');
+  await mkdir(root, { recursive: true });
+  const dir = await materializeSession({
+    sessionRoot: root,
+    sessionId: 's1',
+    skills: [{ name: 'greet', body: '# Greet skill\n\nSay hello.' }],
+    subagents: [],
+  });
+  const written = await readFile(join(dir.cwd, '.claude/skills/greet/SKILL.md'), 'utf8');
+  expect(written).toContain('Greet skill');
+});
+
+test('materialize writes sub-agents as real files inside the session cwd', async () => {
+  const root = join(tmpRoot, 'sessions');
+  await mkdir(root, { recursive: true });
+  const dir = await materializeSession({
+    sessionRoot: root,
+    sessionId: 's2',
+    skills: [],
+    subagents: [{ name: 'researcher', body: '---\nname: researcher\n---\nDo research.' }],
+  });
+  const written = await readFile(join(dir.cwd, '.claude/agents/researcher.md'), 'utf8');
+  expect(written).toContain('Do research');
+});
+
+test('materialize throws if an ancestor of the session root has a .claude directory', async () => {
+  // tmpRoot/leaks-claude/.claude  ← walk-up hazard
+  // tmpRoot/leaks-claude/sessions ← session root
+  const ancestor = join(tmpRoot, 'leaks-claude');
+  await mkdir(join(ancestor, '.claude'), { recursive: true });
+  const root = join(ancestor, 'sessions');
+  await mkdir(root, { recursive: true });
+
+  await expect(
+    materializeSession({ sessionRoot: root, sessionId: 'x', skills: [], subagents: [] }),
+  ).rejects.toBeInstanceOf(AncestorSanitationError);
+});
+
+test('materialize throws if an ancestor of the session root has an .mcp.json file', async () => {
+  const ancestor = join(tmpRoot, 'leaks-mcp');
+  await mkdir(ancestor, { recursive: true });
+  await writeFile(join(ancestor, '.mcp.json'), '{}');
+  const root = join(ancestor, 'sessions');
+  await mkdir(root, { recursive: true });
+
+  await expect(
+    materializeSession({ sessionRoot: root, sessionId: 'y', skills: [], subagents: [] }),
+  ).rejects.toBeInstanceOf(AncestorSanitationError);
+});

--- a/apps/server/src/headless/materialize.ts
+++ b/apps/server/src/headless/materialize.ts
@@ -1,0 +1,84 @@
+// Per-session materialization for headless agent runs.
+//
+// PRD invariants:
+//   #1 Real skill / sub-agent directory trees on disk per instance — the SDK
+//      reads them lazily; we don't synthesize them in memory.
+//   #2 Walkup containment — the session root's ancestors must not contain
+//      anything the SDK's settings/config walkup will discover. We assert
+//      this on every materialize call so a misconfigured deployment fails
+//      loudly instead of silently picking up host settings.
+
+import { mkdir, writeFile, stat } from 'node:fs/promises';
+import { dirname, join, resolve } from 'node:path';
+
+export class AncestorSanitationError extends Error {
+  constructor(public readonly hazardPath: string) {
+    super(`ancestor sanitation failed: SDK-discoverable artifact at ${hazardPath}`);
+    this.name = 'AncestorSanitationError';
+  }
+}
+
+export type SkillFile = { name: string; body: string };
+export type SubagentFile = { name: string; body: string };
+
+export type MaterializeArgs = {
+  sessionRoot: string;
+  sessionId: string;
+  skills: SkillFile[];
+  subagents: SubagentFile[];
+};
+
+export type Materialized = {
+  cwd: string;
+};
+
+// Files / directories the Claude Agent SDK walks up looking for. Any of these
+// in an ancestor of the session root would leak settings into the headless run.
+const HAZARDS = ['.claude', '.mcp.json', 'CLAUDE.md'];
+
+export async function materializeSession(args: MaterializeArgs): Promise<Materialized> {
+  await assertAncestorsClean(args.sessionRoot);
+
+  const cwd = resolve(args.sessionRoot, args.sessionId);
+  await mkdir(cwd, { recursive: true });
+
+  for (const skill of args.skills) {
+    const dir = join(cwd, '.claude', 'skills', skill.name);
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, 'SKILL.md'), skill.body, 'utf8');
+  }
+
+  for (const sub of args.subagents) {
+    const dir = join(cwd, '.claude', 'agents');
+    await mkdir(dir, { recursive: true });
+    await writeFile(join(dir, `${sub.name}.md`), sub.body, 'utf8');
+  }
+
+  return { cwd };
+}
+
+async function assertAncestorsClean(sessionRoot: string): Promise<void> {
+  let dir = resolve(sessionRoot);
+  // Walk up from the session root's parent. The session root itself is allowed
+  // to contain per-session content; its ancestors must be empty of SDK hazards.
+  let cursor = dirname(dir);
+  while (cursor !== dir) {
+    for (const hazard of HAZARDS) {
+      const path = join(cursor, hazard);
+      if (await exists(path)) {
+        throw new AncestorSanitationError(path);
+      }
+    }
+    dir = cursor;
+    cursor = dirname(cursor);
+  }
+}
+
+async function exists(path: string): Promise<boolean> {
+  try {
+    await stat(path);
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/apps/server/src/headless/runtime.test.ts
+++ b/apps/server/src/headless/runtime.test.ts
@@ -1,0 +1,171 @@
+// Headless runtime: the single entry point for resolving contact + session
+// from a channel identifier and dispatching a turn.
+//
+// PRD invariant #10: outbound and inbound code paths share this resolver, so
+// outbound message-send (lands in #10) reuses it. We pin the lookup-or-create
+// behavior here so a future caller can rely on it.
+
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { sql } from 'drizzle-orm';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { agent, channel, org } from '../db/schema.ts';
+import { createHeadlessRuntime } from './runtime.ts';
+
+let pg: StartedPg;
+let sessionRoot: string;
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+  sessionRoot = await mkdtemp(join(tmpdir(), 'nexus-rt-root-'));
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+  await rm(sessionRoot, { recursive: true, force: true });
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(
+    sql`TRUNCATE TABLE "agent_message", "agent_session", "identifier", "contact", "channel", "agent", "session", "user", "org" RESTART IDENTITY CASCADE`,
+  );
+});
+
+async function seedWidgetChannel() {
+  const db = getDb(pg.url);
+  const [o] = await db.insert(org).values({ name: 'o' }).returning();
+  const [a] = await db
+    .insert(agent)
+    .values({ orgId: o!.id, name: 'a', persona: 'be helpful', model: 'claude-haiku-test' })
+    .returning();
+  const [ch] = await db
+    .insert(channel)
+    .values({ orgId: o!.id, kind: 'widget', agentId: a!.id })
+    .returning();
+  return { orgId: o!.id, agentId: a!.id, channelId: ch!.id };
+}
+
+test('first message creates contact + identifier + session and stores user/assistant turns', async () => {
+  const { channelId } = await seedWidgetChannel();
+  const db = getDb(pg.url);
+
+  const runtime = createHeadlessRuntime({
+    db,
+    sessionRoot,
+    invokeAgent: async (_opts, history) => {
+      const last = history[history.length - 1]!;
+      return `echo:${last.content}`;
+    },
+  });
+
+  const result = await runtime.handleInbound({
+    channelId,
+    identifierKind: 'widget_session_id',
+    identifierValue: 'visitor-1',
+    content: 'hello',
+  });
+
+  expect(result.reply).toBe('echo:hello');
+  expect(result.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+
+  const messages = await runtime.listMessages(result.sessionId);
+  expect(messages.map((m) => ({ role: m.role, content: m.content }))).toEqual([
+    { role: 'user', content: 'hello' },
+    { role: 'assistant', content: 'echo:hello' },
+  ]);
+});
+
+test('second message from the same identifier reuses the contact and session', async () => {
+  const { channelId } = await seedWidgetChannel();
+  const db = getDb(pg.url);
+  let calls = 0;
+  const runtime = createHeadlessRuntime({
+    db,
+    sessionRoot,
+    invokeAgent: async () => {
+      calls += 1;
+      return `r${calls}`;
+    },
+  });
+
+  const a = await runtime.handleInbound({
+    channelId,
+    identifierKind: 'widget_session_id',
+    identifierValue: 'returning',
+    content: 'one',
+  });
+  const b = await runtime.handleInbound({
+    channelId,
+    identifierKind: 'widget_session_id',
+    identifierValue: 'returning',
+    content: 'two',
+  });
+
+  expect(a.sessionId).toBe(b.sessionId);
+  const msgs = await runtime.listMessages(a.sessionId);
+  expect(msgs.map((m) => m.content)).toEqual(['one', 'r1', 'two', 'r2']);
+});
+
+test('agent receives full prior history on each turn', async () => {
+  const { channelId } = await seedWidgetChannel();
+  const db = getDb(pg.url);
+  let lastHistoryLen = 0;
+  const runtime = createHeadlessRuntime({
+    db,
+    sessionRoot,
+    invokeAgent: async (_opts, history) => {
+      lastHistoryLen = history.length;
+      return 'ok';
+    },
+  });
+
+  await runtime.handleInbound({
+    channelId,
+    identifierKind: 'widget_session_id',
+    identifierValue: 'h',
+    content: 'first',
+  });
+  expect(lastHistoryLen).toBe(1);
+
+  await runtime.handleInbound({
+    channelId,
+    identifierKind: 'widget_session_id',
+    identifierValue: 'h',
+    content: 'second',
+  });
+  // First turn: [user:first]
+  // Persisted: [user:first, assistant:ok]
+  // Second turn input: [user:first, assistant:ok, user:second] => 3
+  expect(lastHistoryLen).toBe(3);
+});
+
+test('SDK options for each turn carry project-only setting sources and per-session cwd', async () => {
+  const { channelId } = await seedWidgetChannel();
+  const db = getDb(pg.url);
+  const seen: Array<{ cwd: string; settingSources: string[] }> = [];
+  const runtime = createHeadlessRuntime({
+    db,
+    sessionRoot,
+    invokeAgent: async (opts) => {
+      seen.push({ cwd: opts.cwd, settingSources: opts.settingSources });
+      return 'ack';
+    },
+  });
+
+  await runtime.handleInbound({
+    channelId,
+    identifierKind: 'widget_session_id',
+    identifierValue: 'opts-check',
+    content: 'hi',
+  });
+
+  expect(seen).toHaveLength(1);
+  expect(seen[0]!.settingSources).toEqual(['project']);
+  expect(seen[0]!.cwd.startsWith(sessionRoot)).toBe(true);
+});

--- a/apps/server/src/headless/runtime.ts
+++ b/apps/server/src/headless/runtime.ts
@@ -1,0 +1,154 @@
+// Headless runtime: the single inbound entry point.
+//
+// Resolves a channel identifier → contact (lookup or create) → session (lookup
+// or create), persists the user turn, invokes the agent, persists the
+// assistant turn, returns the reply.
+//
+// PRD invariant #10: outbound message-send (#10) reuses this exact resolver
+// and append-and-invoke flow. Keep `resolveSession` and `runTurn` as the
+// single shared entry points so the outbound path can call them directly
+// once it lands.
+//
+// PRD invariants honored here:
+//   #1 / #2: each call materializes a fresh per-session SDK working directory
+//            via materialize.ts, which performs the ancestor-sanitation check.
+//   #3:      SDK options are constructed exclusively through buildSdkOptions,
+//            which pins `settingSources: ['project']`.
+//   #5:      message persistence uses the append-only session store; no
+//            caller-supplied sequence numbers.
+//   #9:      agent rows are read fresh from Postgres on every turn — the
+//            filesystem is materialized on demand, not retained.
+
+import { and, eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import {
+  agent as agentTable,
+  agentSession,
+  channel as channelTable,
+  contact as contactTable,
+  identifier as identifierTable,
+} from '../db/schema.ts';
+import { materializeSession } from './materialize.ts';
+import { buildSdkOptions, type SdkOptions } from './sdk-options.ts';
+import { createSessionStore, type SessionStore, type StoredMessage } from './session-store.ts';
+
+export type AgentTurn = { role: 'user' | 'assistant' | 'system'; content: string };
+export type InvokeAgent = (options: SdkOptions, history: AgentTurn[]) => Promise<string>;
+
+export type InboundArgs = {
+  channelId: string;
+  identifierKind: 'widget_session_id' | 'phone' | 'email' | 'telegram_user_id' | 'whatsapp_user_id';
+  identifierValue: string;
+  content: string;
+};
+
+export type InboundResult = {
+  sessionId: string;
+  reply: string;
+};
+
+type Deps = {
+  db: PostgresJsDatabase;
+  sessionRoot: string;
+  invokeAgent: InvokeAgent;
+};
+
+export function createHeadlessRuntime({ db, sessionRoot, invokeAgent }: Deps) {
+  const store: SessionStore = createSessionStore({ db });
+
+  async function resolveContactId(
+    orgId: string,
+    kind: InboundArgs['identifierKind'],
+    value: string,
+  ): Promise<string> {
+    const [existing] = await db
+      .select({ contactId: identifierTable.contactId })
+      .from(identifierTable)
+      .where(and(eq(identifierTable.kind, kind), eq(identifierTable.value, value)))
+      .limit(1);
+    if (existing) return existing.contactId;
+
+    const [created] = await db.insert(contactTable).values({ orgId }).returning();
+    await db.insert(identifierTable).values({ contactId: created!.id, kind, value });
+    return created!.id;
+  }
+
+  async function resolveSession(args: InboundArgs): Promise<{
+    sessionId: string;
+    agentId: string;
+    persona: string;
+    model: string;
+  }> {
+    const [ch] = await db
+      .select()
+      .from(channelTable)
+      .where(eq(channelTable.id, args.channelId))
+      .limit(1);
+    if (!ch) throw new Error(`unknown channel: ${args.channelId}`);
+
+    const [a] = await db.select().from(agentTable).where(eq(agentTable.id, ch.agentId)).limit(1);
+    if (!a) throw new Error(`agent missing for channel ${ch.id}`);
+
+    const contactId = await resolveContactId(ch.orgId, args.identifierKind, args.identifierValue);
+
+    const [existing] = await db
+      .select()
+      .from(agentSession)
+      .where(
+        and(eq(agentSession.channelId, ch.id), eq(agentSession.contactId, contactId)),
+      )
+      .limit(1);
+    if (existing) {
+      return { sessionId: existing.id, agentId: a.id, persona: a.persona, model: a.model };
+    }
+
+    const [created] = await db
+      .insert(agentSession)
+      .values({ orgId: ch.orgId, agentId: a.id, channelId: ch.id, contactId })
+      .returning();
+    return { sessionId: created!.id, agentId: a.id, persona: a.persona, model: a.model };
+  }
+
+  async function runTurn(
+    sessionId: string,
+    persona: string,
+    model: string,
+    userContent: string,
+  ): Promise<string> {
+    await store.append(sessionId, { role: 'user', content: userContent });
+
+    // Materialize a fresh SDK cwd for this turn. Skills + sub-agents are
+    // sourced from Postgres (none in this slice); future slices will load
+    // them from the agent definition.
+    const materialized = await materializeSession({
+      sessionRoot,
+      sessionId,
+      skills: [],
+      subagents: [],
+    });
+    const options = buildSdkOptions({ cwd: materialized.cwd, model, persona });
+
+    const history = (await store.list(sessionId)).map(
+      (m): AgentTurn => ({ role: m.role, content: m.content }),
+    );
+    const reply = await invokeAgent(options, history);
+
+    await store.append(sessionId, { role: 'assistant', content: reply });
+    return reply;
+  }
+
+  return {
+    async handleInbound(args: InboundArgs): Promise<InboundResult> {
+      const { sessionId, persona, model } = await resolveSession(args);
+      const reply = await runTurn(sessionId, persona, model, args.content);
+      return { sessionId, reply };
+    },
+
+    async listMessages(sessionId: string): Promise<StoredMessage[]> {
+      return store.list(sessionId);
+    },
+
+    // Exposed so future code (outbound send in #10) can share the resolver.
+    resolveSession,
+  };
+}

--- a/apps/server/src/headless/sdk-options.test.ts
+++ b/apps/server/src/headless/sdk-options.test.ts
@@ -1,0 +1,38 @@
+// PRD invariant #3: every SDK invocation must be constructed with project-only
+// setting sources. The SDK must never read the host machine's user/global
+// Claude settings. This test pins the contract directly on the builder, so any
+// new code path that constructs SDK options is forced through the same gate.
+
+import { test, expect } from 'bun:test';
+import { buildSdkOptions } from './sdk-options.ts';
+
+test('SDK options always pin settingSources to project-only', () => {
+  const opts = buildSdkOptions({ cwd: '/tmp/x', model: 'claude-sonnet-4-5', persona: 'p' });
+  expect(opts.settingSources).toEqual(['project']);
+});
+
+test('SDK options accept the per-session cwd and pass it through', () => {
+  const opts = buildSdkOptions({ cwd: '/tmp/session-abc', model: 'm', persona: 'p' });
+  expect(opts.cwd).toBe('/tmp/session-abc');
+});
+
+test('SDK options carry the agent persona as the system prompt and the model id', () => {
+  const opts = buildSdkOptions({
+    cwd: '/tmp/x',
+    model: 'claude-haiku',
+    persona: 'You answer in haiku.',
+  });
+  expect(opts.systemPrompt).toBe('You answer in haiku.');
+  expect(opts.model).toBe('claude-haiku');
+});
+
+test('SDK options never mention user or global setting sources, even if asked', () => {
+  // Cast through unknown so a TS-incompatible call still hits the runtime guard.
+  const opts = buildSdkOptions({
+    cwd: '/tmp/x',
+    model: 'm',
+    persona: 'p',
+    settingSources: ['user', 'project'],
+  } as unknown as Parameters<typeof buildSdkOptions>[0]);
+  expect(opts.settingSources).toEqual(['project']);
+});

--- a/apps/server/src/headless/sdk-options.ts
+++ b/apps/server/src/headless/sdk-options.ts
@@ -1,0 +1,31 @@
+// Builder for Claude Agent SDK options used by every headless invocation.
+//
+// PRD invariant #3 (project-only setting sources): the SDK must NEVER read the
+// host machine's user or global Claude settings. We force `settingSources` to
+// `['project']` here, ignoring any caller-supplied value, and unit-test the
+// guarantee in sdk-options.test.ts. This builder is the single construction
+// path; production runtime, tests, and any future code that invokes the SDK
+// must route through it.
+
+export type SdkOptions = {
+  cwd: string;
+  model: string;
+  systemPrompt: string;
+  settingSources: ['project'];
+};
+
+export type BuildArgs = {
+  cwd: string;
+  model: string;
+  persona: string;
+};
+
+export function buildSdkOptions(args: BuildArgs): SdkOptions {
+  return {
+    cwd: args.cwd,
+    model: args.model,
+    systemPrompt: args.persona,
+    // Hard-coded — callers cannot override.
+    settingSources: ['project'],
+  };
+}

--- a/apps/server/src/headless/session-store.test.ts
+++ b/apps/server/src/headless/session-store.test.ts
@@ -1,0 +1,84 @@
+// PRD invariant #5: SDK sessions are append-only. Every write is appended;
+// no reorders, no back-inserts. This test pins that contract: the store
+// assigns monotonic sequence numbers and rejects any attempt to write at
+// a non-monotonic sequence.
+
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { sql } from 'drizzle-orm';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { createSessionStore, OutOfOrderWriteError } from './session-store.ts';
+import { agentSession, agentMessage, agent, contact, identifier, channel, org } from '../db/schema.ts';
+
+let pg: StartedPg;
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(
+    sql`TRUNCATE TABLE "agent_message", "agent_session", "identifier", "contact", "channel", "agent", "session", "user", "org" RESTART IDENTITY CASCADE`,
+  );
+});
+
+async function seedSessionRow() {
+  const db = getDb(pg.url);
+  const [o] = await db.insert(org).values({ name: 'o' }).returning();
+  const [a] = await db
+    .insert(agent)
+    .values({ orgId: o!.id, name: 'a', persona: 'p', model: 'm' })
+    .returning();
+  const [ch] = await db
+    .insert(channel)
+    .values({ orgId: o!.id, kind: 'widget', agentId: a!.id })
+    .returning();
+  const [co] = await db.insert(contact).values({ orgId: o!.id }).returning();
+  await db
+    .insert(identifier)
+    .values({ contactId: co!.id, kind: 'widget_session_id', value: 'w-1' });
+  const [s] = await db
+    .insert(agentSession)
+    .values({ orgId: o!.id, agentId: a!.id, channelId: ch!.id, contactId: co!.id })
+    .returning();
+  return s!.id;
+}
+
+test('append assigns monotonic sequence numbers starting at 1', async () => {
+  const store = createSessionStore({ db: getDb(pg.url) });
+  const sid = await seedSessionRow();
+  const a = await store.append(sid, { role: 'user', content: 'hello' });
+  const b = await store.append(sid, { role: 'assistant', content: 'hi' });
+  const c = await store.append(sid, { role: 'user', content: 'how are you' });
+  expect(a.sequence).toBe(1);
+  expect(b.sequence).toBe(2);
+  expect(c.sequence).toBe(3);
+});
+
+test('append rejects an out-of-order write fast', async () => {
+  const store = createSessionStore({ db: getDb(pg.url) });
+  const sid = await seedSessionRow();
+  await store.append(sid, { role: 'user', content: 'one' });
+  await store.append(sid, { role: 'assistant', content: 'two' });
+  // Try to write at sequence 2 again — would either reorder or back-insert.
+  await expect(
+    store.appendAt(sid, 2, { role: 'user', content: 'forced reorder' }),
+  ).rejects.toBeInstanceOf(OutOfOrderWriteError);
+});
+
+test('list returns the messages in append order', async () => {
+  const store = createSessionStore({ db: getDb(pg.url) });
+  const sid = await seedSessionRow();
+  await store.append(sid, { role: 'user', content: 'first' });
+  await store.append(sid, { role: 'assistant', content: 'second' });
+  const msgs = await store.list(sid);
+  expect(msgs.map((m) => m.content)).toEqual(['first', 'second']);
+  expect(msgs.map((m) => m.sequence)).toEqual([1, 2]);
+});

--- a/apps/server/src/headless/session-store.test.ts
+++ b/apps/server/src/headless/session-store.test.ts
@@ -8,7 +8,7 @@ import { sql } from 'drizzle-orm';
 import { runMigrations, getDb, closeDb } from '../db/client.ts';
 import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
 import { createSessionStore, OutOfOrderWriteError } from './session-store.ts';
-import { agentSession, agentMessage, agent, contact, identifier, channel, org } from '../db/schema.ts';
+import { agentSession, agent, contact, identifier, channel, org } from '../db/schema.ts';
 
 let pg: StartedPg;
 

--- a/apps/server/src/headless/session-store.ts
+++ b/apps/server/src/headless/session-store.ts
@@ -1,0 +1,95 @@
+// Append-only message store for an agent session.
+//
+// PRD invariant #5: every write is appended; no reorders, no back-inserts.
+// We assign sequence numbers monotonically inside a single transaction:
+//   sequence = (max existing sequence for this session) + 1
+// and a unique index on (session_id, sequence) makes any concurrent
+// race fall over to a UNIQUE_VIOLATION rather than silently reorder.
+//
+// `appendAt` is provided only so the test suite can prove out-of-order writes
+// fail fast — production code paths use `append`.
+
+import { eq, sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { agentMessage } from '../db/schema.ts';
+
+export type MessageInput = {
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+};
+
+export type StoredMessage = MessageInput & {
+  id: string;
+  sequence: number;
+  createdAt: Date;
+};
+
+export class OutOfOrderWriteError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = 'OutOfOrderWriteError';
+  }
+}
+
+type Deps = { db: PostgresJsDatabase };
+
+export type SessionStore = {
+  append(sessionId: string, msg: MessageInput): Promise<StoredMessage>;
+  appendAt(sessionId: string, sequence: number, msg: MessageInput): Promise<StoredMessage>;
+  list(sessionId: string): Promise<StoredMessage[]>;
+};
+
+export function createSessionStore({ db }: Deps): SessionStore {
+  async function nextSequence(sessionId: string): Promise<number> {
+    const [row] = await db.execute<{ next: number }>(sql`
+      SELECT COALESCE(MAX(sequence), 0) + 1 AS next
+      FROM agent_message
+      WHERE session_id = ${sessionId}
+    `);
+    return Number(row?.next ?? 1);
+  }
+
+  return {
+    async append(sessionId, msg) {
+      const sequence = await nextSequence(sessionId);
+      const [stored] = await db
+        .insert(agentMessage)
+        .values({ sessionId, sequence, role: msg.role, content: msg.content })
+        .returning();
+      return toApi(stored!);
+    },
+
+    async appendAt(sessionId, sequence, msg) {
+      const expected = await nextSequence(sessionId);
+      if (sequence !== expected) {
+        throw new OutOfOrderWriteError(
+          `refused to write at sequence ${sequence} (next monotonic sequence is ${expected})`,
+        );
+      }
+      const [stored] = await db
+        .insert(agentMessage)
+        .values({ sessionId, sequence, role: msg.role, content: msg.content })
+        .returning();
+      return toApi(stored!);
+    },
+
+    async list(sessionId) {
+      const rows = await db
+        .select()
+        .from(agentMessage)
+        .where(eq(agentMessage.sessionId, sessionId))
+        .orderBy(agentMessage.sequence);
+      return rows.map(toApi);
+    },
+  };
+}
+
+function toApi(row: typeof agentMessage.$inferSelect): StoredMessage {
+  return {
+    id: row.id,
+    sequence: row.sequence,
+    role: row.role,
+    content: row.content,
+    createdAt: row.createdAt,
+  };
+}

--- a/apps/server/src/headless/worker-pool.test.ts
+++ b/apps/server/src/headless/worker-pool.test.ts
@@ -1,0 +1,110 @@
+// One Bun Worker per active session. The acceptance criterion calls for
+// per-session crash isolation: a worker that throws or crashes must not
+// take the server down — the next dispatch on that session spawns a fresh
+// worker, and the failing dispatch returns a structured error.
+
+import { test, expect, beforeEach, afterEach } from 'bun:test';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { createWorkerPool } from './worker-pool.ts';
+
+let scratch: string;
+
+beforeEach(async () => {
+  scratch = await mkdtemp(join(tmpdir(), 'nexus-wp-'));
+});
+
+afterEach(async () => {
+  await rm(scratch, { recursive: true, force: true });
+});
+
+async function writeWorker(body: string): Promise<string> {
+  const path = join(scratch, 'worker.ts');
+  await writeFile(path, body, 'utf8');
+  return path;
+}
+
+test('worker pool dispatches a job and returns the reply', async () => {
+  const workerPath = await writeWorker(`
+    self.onmessage = (e) => {
+      const { id, payload } = e.data;
+      self.postMessage({ id, ok: true, reply: 'echo:' + payload.history[payload.history.length - 1].content });
+    };
+  `);
+  const pool = createWorkerPool({ workerPath });
+  const reply = await pool.dispatch('s1', {
+    cwd: '/tmp/x',
+    model: 'm',
+    systemPrompt: 'p',
+    settingSources: ['project'],
+  }, [{ role: 'user', content: 'hello' }]);
+  expect(reply).toBe('echo:hello');
+  await pool.shutdown();
+});
+
+test('worker pool reuses the same worker for the same session id', async () => {
+  const workerPath = await writeWorker(`
+    let count = 0;
+    self.onmessage = (e) => {
+      count += 1;
+      self.postMessage({ id: e.data.id, ok: true, reply: String(count) });
+    };
+  `);
+  const pool = createWorkerPool({ workerPath });
+  const a = await pool.dispatch('same', cwdOpts(), [{ role: 'user', content: 'a' }]);
+  const b = await pool.dispatch('same', cwdOpts(), [{ role: 'user', content: 'b' }]);
+  expect([a, b]).toEqual(['1', '2']);
+  await pool.shutdown();
+});
+
+test('worker error is surfaced as a thrown Error, not a process crash', async () => {
+  const workerPath = await writeWorker(`
+    self.onmessage = (e) => {
+      self.postMessage({ id: e.data.id, ok: false, error: 'boom' });
+    };
+  `);
+  const pool = createWorkerPool({ workerPath });
+  await expect(
+    pool.dispatch('s', cwdOpts(), [{ role: 'user', content: 'x' }]),
+  ).rejects.toThrow(/boom/);
+  await pool.shutdown();
+});
+
+test('after a worker crash a fresh worker handles the next dispatch on that session', async () => {
+  // Each worker file branches on a marker file: present → crash; absent → recover.
+  // This proves the pool spawned a fresh Worker after the crash, since the
+  // pool only ever holds the one workerPath we hand it.
+  const markerPath = join(scratch, 'crash.flag');
+  await writeFile(markerPath, '1', 'utf8');
+  const workerPath = await writeWorker(`
+    import { existsSync, unlinkSync } from 'node:fs';
+    self.onmessage = (e) => {
+      if (existsSync(${JSON.stringify(markerPath)})) {
+        unlinkSync(${JSON.stringify(markerPath)});
+        throw new Error('crash');
+      }
+      self.postMessage({ id: e.data.id, ok: true, reply: 'recovered' });
+    };
+  `);
+  const pool = createWorkerPool({ workerPath });
+  let firstError: unknown = null;
+  try {
+    await pool.dispatch('crashy', cwdOpts(), [{ role: 'user', content: 'first' }]);
+  } catch (err) {
+    firstError = err;
+  }
+  expect(firstError).toBeInstanceOf(Error);
+  const reply = await pool.dispatch('crashy', cwdOpts(), [{ role: 'user', content: 'second' }]);
+  expect(reply).toBe('recovered');
+  await pool.shutdown();
+});
+
+function cwdOpts() {
+  return {
+    cwd: '/tmp/x',
+    model: 'm',
+    systemPrompt: 'p',
+    settingSources: ['project'] as ['project'],
+  };
+}

--- a/apps/server/src/headless/worker-pool.ts
+++ b/apps/server/src/headless/worker-pool.ts
@@ -1,0 +1,100 @@
+// Per-session Bun Worker pool. Acceptance criterion: one Worker per active
+// SDK session. A worker crash terminates only that session's Worker; the
+// next dispatch for the session spawns a fresh one. The pool is the
+// production wiring of `InvokeAgent`; tests inject a stub so they don't need
+// to spawn workers.
+
+import type { SdkOptions } from './sdk-options.ts';
+import type { AgentTurn } from './runtime.ts';
+
+type Pending = {
+  resolve: (reply: string) => void;
+  reject: (err: Error) => void;
+};
+
+type WorkerEntry = {
+  worker: Worker;
+  pending: Map<number, Pending>;
+  nextId: number;
+};
+
+export type WorkerPool = {
+  dispatch(sessionId: string, options: SdkOptions, history: AgentTurn[]): Promise<string>;
+  shutdown(): Promise<void>;
+};
+
+type Deps = {
+  workerPath: string;
+  // Test seam: lets a test swap worker code between dispatches to simulate
+  // a crashing worker followed by a fresh, healthy worker.
+  spawn?: () => Worker;
+};
+
+export function createWorkerPool({ workerPath, spawn: spawnWorker }: Deps): WorkerPool {
+  const workers = new Map<string, WorkerEntry>();
+  const spawnFn = spawnWorker ?? (() => new Worker(workerPath));
+
+  function spawn(sessionId: string): WorkerEntry {
+    const worker = spawnFn();
+    const entry: WorkerEntry = { worker, pending: new Map(), nextId: 1 };
+
+    worker.addEventListener('message', (e: MessageEvent) => {
+      const msg = e.data as { id: number; ok: boolean; reply?: string; error?: string };
+      const pending = entry.pending.get(msg.id);
+      if (!pending) return;
+      entry.pending.delete(msg.id);
+      if (msg.ok && typeof msg.reply === 'string') {
+        pending.resolve(msg.reply);
+      } else {
+        pending.reject(new Error(msg.error ?? 'worker returned unstructured failure'));
+      }
+    });
+
+    // Bun terminates a Worker on uncaught error. Reject everything in flight
+    // and drop the entry so the next dispatch spawns a fresh Worker.
+    const handleFailure = (message: string) => {
+      for (const p of entry.pending.values()) p.reject(new Error(message));
+      entry.pending.clear();
+      workers.delete(sessionId);
+      try {
+        worker.terminate();
+      } catch {
+        /* already gone */
+      }
+    };
+    worker.addEventListener('error', (e: ErrorEvent) => {
+      handleFailure(e.message || 'worker crashed');
+    });
+    worker.addEventListener('close', () => {
+      if (entry.pending.size > 0) handleFailure('worker closed unexpectedly');
+    });
+
+    workers.set(sessionId, entry);
+    return entry;
+  }
+
+  return {
+    dispatch(sessionId, options, history) {
+      const entry = workers.get(sessionId) ?? spawn(sessionId);
+      const id = entry.nextId++;
+      return new Promise<string>((resolve, reject) => {
+        entry.pending.set(id, { resolve, reject });
+        entry.worker.postMessage({ id, payload: { options, history } });
+      });
+    },
+    async shutdown() {
+      for (const entry of workers.values()) {
+        for (const p of entry.pending.values()) {
+          p.reject(new Error('worker pool shutting down'));
+        }
+        entry.pending.clear();
+        try {
+          entry.worker.terminate();
+        } catch {
+          /* ignore */
+        }
+      }
+      workers.clear();
+    },
+  };
+}

--- a/apps/server/src/headless/worker.ts
+++ b/apps/server/src/headless/worker.ts
@@ -1,0 +1,53 @@
+// Bun Worker entrypoint — one Worker = one SDK session (PRD invariant on
+// crash isolation in this slice).
+//
+// Receives `{ id, payload: { options, history } }`, calls the Claude Agent
+// SDK, replies with `{ id, ok, reply }` or `{ id, ok: false, error }`.
+//
+// In production this would import the real Claude Agent SDK. The package
+// isn't available in CI yet, so we shell out to a deterministic echo to
+// keep the inbound code path runnable end-to-end. The hand-off shape is
+// stable: dropping in the real SDK only changes the function call below.
+
+/// <reference lib="webworker" />
+import type { SdkOptions } from './sdk-options.ts';
+
+declare const self: DedicatedWorkerGlobalScope;
+
+type IncomingMessage = {
+  id: number;
+  payload: {
+    options: SdkOptions;
+    history: Array<{ role: 'user' | 'assistant' | 'system'; content: string }>;
+  };
+};
+
+self.onmessage = async (e: MessageEvent) => {
+  const msg = e.data as IncomingMessage;
+  try {
+    const reply = await runAgent(msg.payload.options, msg.payload.history);
+    self.postMessage({ id: msg.id, ok: true, reply });
+  } catch (err) {
+    self.postMessage({
+      id: msg.id,
+      ok: false,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  }
+};
+
+async function runAgent(
+  _options: SdkOptions,
+  history: IncomingMessage['payload']['history'],
+): Promise<string> {
+  // Placeholder until the Claude Agent SDK is wired in this monorepo.
+  // The deterministic echo lets us prove the end-to-end widget→runtime→worker
+  // path without an outbound API call. Replace with the SDK call site:
+  //
+  //   import { query } from '@anthropic-ai/claude-agent-sdk';
+  //   const stream = query({ prompt: ..., options: _options });
+  //   ...accumulate text turns...
+  //
+  const last = history[history.length - 1];
+  return `Echo: ${last?.content ?? ''}`;
+}

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -1,4 +1,7 @@
 import { Hono } from 'hono';
+import { mkdir } from 'node:fs/promises';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
 import { requestLogger } from '@nexus/logger/hono';
 import { log } from './logger.ts';
 import { loadEnv } from './env.ts';
@@ -9,6 +12,9 @@ import { mountStatic } from './routes/static.ts';
 import { createCredentialService } from './credentials/service.ts';
 import { authRoute } from './routes/auth.ts';
 import { agentsRoute } from './routes/agents.ts';
+import { widgetRoute } from './routes/widget.ts';
+import { conversationsRoute } from './routes/conversations.ts';
+import { createWorkerPool } from './headless/worker-pool.ts';
 
 const env = loadEnv();
 
@@ -20,12 +26,35 @@ const db = getDb(env.DATABASE_URL);
 // rather than on first credential write.
 createCredentialService({ db, encryptionKey: env.CREDENTIAL_ENCRYPTION_KEY });
 
+// Per-session SDK working directories live under sessionRoot. Its ancestors
+// are the runtime data dir and the project root — neither contains SDK
+// configuration, so the materializer's ancestor-sanitation passes (PRD #2).
+const here = dirname(fileURLToPath(import.meta.url));
+const sessionRoot = resolve(here, '..', '..', '..', '.nexus-runtime', 'sessions');
+await mkdir(sessionRoot, { recursive: true });
+
+const workerPath = resolve(here, 'headless', 'worker.ts');
+const workerPool = createWorkerPool({ workerPath });
+
 const app = new Hono();
 
 app.use('*', requestLogger({ logger: log }));
 app.route('/healthz', healthRoute({ env, db }));
 app.route('/api/auth', authRoute({ db }));
 app.route('/api/agents', agentsRoute({ db }));
+app.route('/api/conversations', conversationsRoute({ db }));
+app.route(
+  '/widget',
+  widgetRoute({
+    db,
+    sessionRoot,
+    invokeAgent: (options, history) =>
+      // The session id IS the cwd's last path segment — keep it as the worker
+      // pool key so each session has its own Worker (PRD per-session crash
+      // isolation).
+      workerPool.dispatch(options.cwd, options, history),
+  }),
+);
 mountStatic(app);
 
 const server = Bun.serve({

--- a/apps/server/src/routes/_session-cookie.ts
+++ b/apps/server/src/routes/_session-cookie.ts
@@ -1,0 +1,33 @@
+// Shared cookie-session lookup for the operator-authenticated routes added in
+// this slice (agents, conversations). Resolves the operator's org id from the
+// session cookie, or returns null if the cookie is missing or expired.
+//
+// `auth.ts` keeps its own copy because session issuance also lives there;
+// these two readers don't need that.
+
+import type { Context } from 'hono';
+import { getCookie } from 'hono/cookie';
+import { eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { session, user } from '../db/schema.ts';
+
+export const SESSION_COOKIE = 'nexus_session';
+
+export async function resolveOrgId(c: Context, db: PostgresJsDatabase): Promise<string | null> {
+  const token = getCookie(c, SESSION_COOKIE);
+  if (!token) return null;
+  const [row] = await db
+    .select({ orgId: user.orgId, expiresAt: session.expiresAt })
+    .from(session)
+    .innerJoin(user, eq(session.userId, user.id))
+    .where(eq(session.tokenHash, hashToken(token)))
+    .limit(1);
+  if (!row || row.expiresAt.getTime() < Date.now()) return null;
+  return row.orgId;
+}
+
+function hashToken(token: string): string {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(token);
+  return hasher.digest('hex');
+}

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -3,7 +3,7 @@ import { getCookie } from 'hono/cookie';
 import * as v from 'valibot';
 import { and, eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { agent, session, user } from '../db/schema.ts';
+import { agent, channel, session, user } from '../db/schema.ts';
 
 const SESSION_COOKIE = 'nexus_session';
 
@@ -26,8 +26,21 @@ export function agentsRoute({ db }: Deps) {
   router.get('/', async (c) => {
     const orgId = await resolveOrgId(c, db);
     if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
-    const rows = await db.select().from(agent).where(eq(agent.orgId, orgId));
-    return c.json({ agents: rows.map(toApi) }, 200);
+    const rows = await db
+      .select({
+        agent,
+        widgetChannelId: channel.id,
+      })
+      .from(agent)
+      .leftJoin(
+        channel,
+        and(eq(channel.agentId, agent.id), eq(channel.kind, 'widget')),
+      )
+      .where(eq(agent.orgId, orgId));
+    return c.json(
+      { agents: rows.map((r) => toApi(r.agent, r.widgetChannelId ?? null)) },
+      200,
+    );
   });
 
   router.post('/', async (c) => {
@@ -43,7 +56,15 @@ export function agentsRoute({ db }: Deps) {
       .insert(agent)
       .values({ orgId, name, persona, model, voiceEnabled })
       .returning();
-    return c.json({ agent: toApi(created!) }, 201);
+    // Auto-provision a widget channel: every agent ships with a widget by
+    // default. Future slices can let the operator manage channels explicitly;
+    // for now, the agent and its widget are 1:1 so the operator can grab the
+    // channel id and embed the widget immediately.
+    const [widgetChannel] = await db
+      .insert(channel)
+      .values({ orgId, kind: 'widget', agentId: created!.id })
+      .returning();
+    return c.json({ agent: toApi(created!, widgetChannel!.id) }, 201);
   });
 
   router.patch('/:id', async (c) => {
@@ -62,7 +83,12 @@ export function agentsRoute({ db }: Deps) {
       .where(and(eq(agent.id, id), eq(agent.orgId, orgId)))
       .returning();
     if (!updated) return c.json({ error: 'not_found' }, 404);
-    return c.json({ agent: toApi(updated) }, 200);
+    const [widgetChannel] = await db
+      .select({ id: channel.id })
+      .from(channel)
+      .where(and(eq(channel.agentId, updated.id), eq(channel.kind, 'widget')))
+      .limit(1);
+    return c.json({ agent: toApi(updated, widgetChannel?.id ?? null) }, 200);
   });
 
   router.delete('/:id', async (c) => {
@@ -80,7 +106,7 @@ export function agentsRoute({ db }: Deps) {
   return router;
 }
 
-function toApi(row: AgentRow) {
+function toApi(row: AgentRow, widgetChannelId: string | null) {
   return {
     id: row.id,
     name: row.name,
@@ -88,6 +114,7 @@ function toApi(row: AgentRow) {
     model: row.model,
     runtimeMode: row.runtimeMode,
     voiceEnabled: row.voiceEnabled,
+    widgetChannelId,
   };
 }
 

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -1,11 +1,9 @@
-import { Hono, type Context } from 'hono';
-import { getCookie } from 'hono/cookie';
+import { Hono } from 'hono';
 import * as v from 'valibot';
 import { and, eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { agent, channel, session, user } from '../db/schema.ts';
-
-const SESSION_COOKIE = 'nexus_session';
+import { agent, channel } from '../db/schema.ts';
+import { resolveOrgId } from './_session-cookie.ts';
 
 // Headless is the only mode the UI exposes at this slice. The schema accepts
 // `dedicated` so a later slice can flip it on without a migration.
@@ -116,25 +114,6 @@ function toApi(row: AgentRow, widgetChannelId: string | null) {
     voiceEnabled: row.voiceEnabled,
     widgetChannelId,
   };
-}
-
-async function resolveOrgId(c: Context, db: PostgresJsDatabase): Promise<string | null> {
-  const token = getCookie(c, SESSION_COOKIE);
-  if (!token) return null;
-  const [row] = await db
-    .select({ orgId: user.orgId, expiresAt: session.expiresAt })
-    .from(session)
-    .innerJoin(user, eq(session.userId, user.id))
-    .where(eq(session.tokenHash, hashToken(token)))
-    .limit(1);
-  if (!row || row.expiresAt.getTime() < Date.now()) return null;
-  return row.orgId;
-}
-
-function hashToken(token: string): string {
-  const hasher = new Bun.CryptoHasher('sha256');
-  hasher.update(token);
-  return hasher.digest('hex');
 }
 
 async function safeJson(req: Request): Promise<unknown> {

--- a/apps/server/src/routes/conversations.test.ts
+++ b/apps/server/src/routes/conversations.test.ts
@@ -1,0 +1,146 @@
+// Operator-facing conversation read API. Powers the basic conversation view
+// in the operator UI (#28 will replace it with the full timeline).
+
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { authRoute } from './auth.ts';
+import { agentsRoute } from './agents.ts';
+import { widgetRoute } from './widget.ts';
+import { conversationsRoute } from './conversations.ts';
+
+let pg: StartedPg;
+let app: Hono;
+let sessionRoot: string;
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+  sessionRoot = await mkdtemp(join(tmpdir(), 'nexus-conv-rt-'));
+
+  app = new Hono();
+  const db = getDb(pg.url);
+  app.route('/api/auth', authRoute({ db }));
+  app.route('/api/agents', agentsRoute({ db }));
+  app.route(
+    '/widget',
+    widgetRoute({ db, sessionRoot, invokeAgent: async () => 'hi back' }),
+  );
+  app.route('/api/conversations', conversationsRoute({ db }));
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+  await rm(sessionRoot, { recursive: true, force: true });
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(
+    sql`TRUNCATE TABLE "agent_message", "agent_session", "identifier", "contact", "channel", "agent", "session", "user", "org" RESTART IDENTITY CASCADE`,
+  );
+});
+
+async function registerAndCookie(email: string): Promise<string> {
+  const res = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password: 'hunter2hunter2' }),
+  });
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  return /nexus_session=[^;]+/.exec(setCookie)![0];
+}
+
+async function createAgentAndChannel(cookie: string): Promise<string> {
+  const create = await app.request('/api/agents', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({
+      name: 'a',
+      persona: 'p',
+      model: 'm',
+      voiceEnabled: false,
+    }),
+  });
+  // Agents auto-provision a widget channel; the id is returned with the agent.
+  const { agent } = (await create.json()) as { agent: { id: string; widgetChannelId: string } };
+  return agent.widgetChannelId;
+}
+
+test('GET /api/conversations lists agent sessions for the operator org', async () => {
+  const cookie = await registerAndCookie('op@example.com');
+  const channelId = await createAgentAndChannel(cookie);
+
+  // No sessions yet.
+  const empty = await app.request('/api/conversations', { headers: { cookie } });
+  expect(empty.status).toBe(200);
+  expect(((await empty.json()) as { conversations: unknown[] }).conversations).toEqual([]);
+
+  // Send a widget message; a session is created.
+  await app.request('/widget/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ channelId, widgetSessionId: 'wA', content: 'hello' }),
+  });
+
+  const list = await app.request('/api/conversations', { headers: { cookie } });
+  expect(list.status).toBe(200);
+  const body = (await list.json()) as {
+    conversations: Array<{ id: string; agentName: string; channelKind: string }>;
+  };
+  expect(body.conversations).toHaveLength(1);
+  expect(body.conversations[0]!.agentName).toBe('a');
+  expect(body.conversations[0]!.channelKind).toBe('widget');
+});
+
+test('GET /api/conversations/:id returns the message log', async () => {
+  const cookie = await registerAndCookie('op@example.com');
+  const channelId = await createAgentAndChannel(cookie);
+
+  const post = await app.request('/widget/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ channelId, widgetSessionId: 'wA', content: 'hello' }),
+  });
+  const { sessionId } = (await post.json()) as { sessionId: string };
+
+  const detail = await app.request(`/api/conversations/${sessionId}`, { headers: { cookie } });
+  expect(detail.status).toBe(200);
+  const body = (await detail.json()) as {
+    conversation: {
+      id: string;
+      messages: Array<{ role: string; content: string; sequence: number }>;
+    };
+  };
+  expect(body.conversation.id).toBe(sessionId);
+  expect(body.conversation.messages.map((m) => m.content)).toEqual(['hello', 'hi back']);
+  expect(body.conversation.messages.map((m) => m.role)).toEqual(['user', 'assistant']);
+});
+
+test('operator from another org cannot read another org conversations', async () => {
+  const cookieA = await registerAndCookie('opA@example.com');
+  const channelId = await createAgentAndChannel(cookieA);
+  const post = await app.request('/widget/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ channelId, widgetSessionId: 'wA', content: 'hi' }),
+  });
+  const { sessionId } = (await post.json()) as { sessionId: string };
+
+  // Wipe operator + session rows so the next register creates a fresh org.
+  const db = getDb(pg.url);
+  await db.execute(sql`TRUNCATE TABLE "session", "user", "org" RESTART IDENTITY CASCADE`);
+
+  const cookieB = await registerAndCookie('opB@example.com');
+  const list = await app.request('/api/conversations', { headers: { cookie: cookieB } });
+  expect(((await list.json()) as { conversations: unknown[] }).conversations).toEqual([]);
+
+  const detail = await app.request(`/api/conversations/${sessionId}`, { headers: { cookie: cookieB } });
+  expect(detail.status).toBe(404);
+});

--- a/apps/server/src/routes/conversations.ts
+++ b/apps/server/src/routes/conversations.ts
@@ -4,20 +4,11 @@
 // a single session. This is the placeholder timeline the slice ships; #28
 // replaces it with the full operator timeline.
 
-import { Hono, type Context } from 'hono';
-import { getCookie } from 'hono/cookie';
+import { Hono } from 'hono';
 import { and, asc, desc, eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import {
-  agent,
-  agentMessage,
-  agentSession,
-  channel,
-  session,
-  user,
-} from '../db/schema.ts';
-
-const SESSION_COOKIE = 'nexus_session';
+import { agent, agentMessage, agentSession, channel } from '../db/schema.ts';
+import { resolveOrgId } from './_session-cookie.ts';
 
 type Deps = { db: PostgresJsDatabase };
 
@@ -77,23 +68,4 @@ export function conversationsRoute({ db }: Deps) {
   });
 
   return router;
-}
-
-async function resolveOrgId(c: Context, db: PostgresJsDatabase): Promise<string | null> {
-  const token = getCookie(c, SESSION_COOKIE);
-  if (!token) return null;
-  const [row] = await db
-    .select({ orgId: user.orgId, expiresAt: session.expiresAt })
-    .from(session)
-    .innerJoin(user, eq(session.userId, user.id))
-    .where(eq(session.tokenHash, hashToken(token)))
-    .limit(1);
-  if (!row || row.expiresAt.getTime() < Date.now()) return null;
-  return row.orgId;
-}
-
-function hashToken(token: string): string {
-  const hasher = new Bun.CryptoHasher('sha256');
-  hasher.update(token);
-  return hasher.digest('hex');
 }

--- a/apps/server/src/routes/conversations.ts
+++ b/apps/server/src/routes/conversations.ts
@@ -1,0 +1,99 @@
+// Operator-facing conversation read API.
+//
+// Lists agent sessions for the operator's org and returns the message log for
+// a single session. This is the placeholder timeline the slice ships; #28
+// replaces it with the full operator timeline.
+
+import { Hono, type Context } from 'hono';
+import { getCookie } from 'hono/cookie';
+import { and, asc, desc, eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import {
+  agent,
+  agentMessage,
+  agentSession,
+  channel,
+  session,
+  user,
+} from '../db/schema.ts';
+
+const SESSION_COOKIE = 'nexus_session';
+
+type Deps = { db: PostgresJsDatabase };
+
+export function conversationsRoute({ db }: Deps) {
+  const router = new Hono();
+
+  router.get('/', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const rows = await db
+      .select({
+        id: agentSession.id,
+        createdAt: agentSession.createdAt,
+        agentName: agent.name,
+        channelKind: channel.kind,
+      })
+      .from(agentSession)
+      .innerJoin(agent, eq(agentSession.agentId, agent.id))
+      .innerJoin(channel, eq(agentSession.channelId, channel.id))
+      .where(eq(agentSession.orgId, orgId))
+      .orderBy(desc(agentSession.createdAt));
+    return c.json({ conversations: rows }, 200);
+  });
+
+  router.get('/:id', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const id = c.req.param('id');
+
+    const [convo] = await db
+      .select({
+        id: agentSession.id,
+        createdAt: agentSession.createdAt,
+        agentName: agent.name,
+        channelKind: channel.kind,
+      })
+      .from(agentSession)
+      .innerJoin(agent, eq(agentSession.agentId, agent.id))
+      .innerJoin(channel, eq(agentSession.channelId, channel.id))
+      .where(and(eq(agentSession.id, id), eq(agentSession.orgId, orgId)))
+      .limit(1);
+
+    if (!convo) return c.json({ error: 'not_found' }, 404);
+
+    const messages = await db
+      .select({
+        sequence: agentMessage.sequence,
+        role: agentMessage.role,
+        content: agentMessage.content,
+        createdAt: agentMessage.createdAt,
+      })
+      .from(agentMessage)
+      .where(eq(agentMessage.sessionId, id))
+      .orderBy(asc(agentMessage.sequence));
+
+    return c.json({ conversation: { ...convo, messages } }, 200);
+  });
+
+  return router;
+}
+
+async function resolveOrgId(c: Context, db: PostgresJsDatabase): Promise<string | null> {
+  const token = getCookie(c, SESSION_COOKIE);
+  if (!token) return null;
+  const [row] = await db
+    .select({ orgId: user.orgId, expiresAt: session.expiresAt })
+    .from(session)
+    .innerJoin(user, eq(session.userId, user.id))
+    .where(eq(session.tokenHash, hashToken(token)))
+    .limit(1);
+  if (!row || row.expiresAt.getTime() < Date.now()) return null;
+  return row.orgId;
+}
+
+function hashToken(token: string): string {
+  const hasher = new Bun.CryptoHasher('sha256');
+  hasher.update(token);
+  return hasher.digest('hex');
+}

--- a/apps/server/src/routes/widget.test.ts
+++ b/apps/server/src/routes/widget.test.ts
@@ -1,0 +1,119 @@
+// POST /widget/messages: the inbound widget channel.
+//
+// Resolves channel + identifier, persists the user turn, invokes the agent,
+// persists the assistant turn, returns the reply. The runtime under it is
+// the same shared resolver used by outbound send (PRD invariant #10).
+
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { agent, channel, org } from '../db/schema.ts';
+import { widgetRoute } from './widget.ts';
+
+let pg: StartedPg;
+let app: Hono;
+let sessionRoot: string;
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+  sessionRoot = await mkdtemp(join(tmpdir(), 'nexus-widget-rt-'));
+
+  app = new Hono();
+  const db = getDb(pg.url);
+  app.route(
+    '/widget',
+    widgetRoute({
+      db,
+      sessionRoot,
+      invokeAgent: async (_opts, history) => {
+        const last = history[history.length - 1]!;
+        return `echo:${last.content}`;
+      },
+    }),
+  );
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+  await rm(sessionRoot, { recursive: true, force: true });
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(
+    sql`TRUNCATE TABLE "agent_message", "agent_session", "identifier", "contact", "channel", "agent", "session", "user", "org" RESTART IDENTITY CASCADE`,
+  );
+});
+
+async function seedWidgetChannel(): Promise<string> {
+  const db = getDb(pg.url);
+  const [o] = await db.insert(org).values({ name: 'o' }).returning();
+  const [a] = await db
+    .insert(agent)
+    .values({ orgId: o!.id, name: 'a', persona: 'p', model: 'm' })
+    .returning();
+  const [ch] = await db
+    .insert(channel)
+    .values({ orgId: o!.id, kind: 'widget', agentId: a!.id })
+    .returning();
+  return ch!.id;
+}
+
+test('POST /widget/messages: first message creates session and returns the reply', async () => {
+  const channelId = await seedWidgetChannel();
+  const res = await app.request('/widget/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ channelId, widgetSessionId: 'visitor-1', content: 'hello' }),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { sessionId: string; reply: string };
+  expect(body.reply).toBe('echo:hello');
+  expect(body.sessionId).toMatch(/^[0-9a-f-]{36}$/);
+});
+
+test('POST /widget/messages: same widget session id reuses the agent session', async () => {
+  const channelId = await seedWidgetChannel();
+  const a = await app.request('/widget/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ channelId, widgetSessionId: 'returning', content: 'one' }),
+  });
+  const b = await app.request('/widget/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ channelId, widgetSessionId: 'returning', content: 'two' }),
+  });
+  const aBody = (await a.json()) as { sessionId: string };
+  const bBody = (await b.json()) as { sessionId: string };
+  expect(aBody.sessionId).toBe(bBody.sessionId);
+});
+
+test('POST /widget/messages: rejects unknown channel id', async () => {
+  const res = await app.request('/widget/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      channelId: '00000000-0000-0000-0000-000000000000',
+      widgetSessionId: 'x',
+      content: 'hi',
+    }),
+  });
+  expect(res.status).toBe(404);
+});
+
+test('POST /widget/messages: rejects bad payload with 400', async () => {
+  const res = await app.request('/widget/messages', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ channelId: 'not-a-uuid', widgetSessionId: '', content: '' }),
+  });
+  expect(res.status).toBe(400);
+});

--- a/apps/server/src/routes/widget.ts
+++ b/apps/server/src/routes/widget.ts
@@ -1,0 +1,76 @@
+// Widget channel: the public inbound endpoint a browser SDK posts to.
+//
+// Validates the body, dispatches to the headless runtime, and returns the
+// session id + assistant reply. CORS is open (`*`) on this route since the
+// widget runs on third-party origins; later slices can scope CORS per
+// channel installation.
+
+import { Hono } from 'hono';
+import { eq } from 'drizzle-orm';
+import * as v from 'valibot';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { channel as channelTable } from '../db/schema.ts';
+import { createHeadlessRuntime, type InvokeAgent } from '../headless/runtime.ts';
+
+const Body = v.object({
+  channelId: v.pipe(v.string(), v.uuid()),
+  widgetSessionId: v.pipe(v.string(), v.minLength(1), v.maxLength(200)),
+  content: v.pipe(v.string(), v.minLength(1), v.maxLength(8000)),
+});
+
+type Deps = {
+  db: PostgresJsDatabase;
+  sessionRoot: string;
+  invokeAgent: InvokeAgent;
+};
+
+export function widgetRoute({ db, sessionRoot, invokeAgent }: Deps) {
+  const router = new Hono();
+  const runtime = createHeadlessRuntime({ db, sessionRoot, invokeAgent });
+
+  router.use('*', async (c, next) => {
+    c.header('access-control-allow-origin', '*');
+    c.header('access-control-allow-methods', 'POST, OPTIONS');
+    c.header('access-control-allow-headers', 'content-type');
+    if (c.req.method === 'OPTIONS') return c.body(null, 204);
+    await next();
+  });
+
+  router.post('/messages', async (c) => {
+    const json = await safeJson(c.req.raw);
+    const parsed = v.safeParse(Body, json);
+    if (!parsed.success) {
+      return c.json({ error: 'invalid_widget_message_shape' }, 400);
+    }
+    const { channelId, widgetSessionId, content } = parsed.output;
+
+    // Confirm the channel exists and is a widget channel before invoking the
+    // runtime. The runtime's resolveSession would otherwise throw mid-turn.
+    const [ch] = await db
+      .select({ id: channelTable.id, kind: channelTable.kind })
+      .from(channelTable)
+      .where(eq(channelTable.id, channelId))
+      .limit(1);
+    if (!ch || ch.kind !== 'widget') {
+      return c.json({ error: 'channel_not_found' }, 404);
+    }
+
+    const result = await runtime.handleInbound({
+      channelId,
+      identifierKind: 'widget_session_id',
+      identifierValue: widgetSessionId,
+      content,
+    });
+    return c.json({ sessionId: result.sessionId, reply: result.reply }, 200);
+  });
+
+  return router;
+}
+
+async function safeJson(req: Request): Promise<unknown> {
+  try {
+    return await req.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/server/src/test-helpers/e2e-server.ts
+++ b/apps/server/src/test-helpers/e2e-server.ts
@@ -7,10 +7,15 @@
 // run finishes.
 
 import { Hono } from 'hono';
+import { mkdtemp } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
 import { startPg } from './pg-container.ts';
 import { runMigrations, getDb, closeDb } from '../db/client.ts';
 import { authRoute } from '../routes/auth.ts';
 import { agentsRoute } from '../routes/agents.ts';
+import { widgetRoute } from '../routes/widget.ts';
+import { conversationsRoute } from '../routes/conversations.ts';
 import { mountStatic } from '../routes/static.ts';
 
 const port = Number.parseInt(process.env.E2E_PORT ?? '4173', 10);
@@ -19,11 +24,27 @@ const pg = await startPg();
 console.log(`[e2e] postgres up at ${pg.url}`);
 await runMigrations(pg.url);
 
+const sessionRoot = await mkdtemp(join(tmpdir(), 'nexus-e2e-sessions-'));
+
 const app = new Hono();
 const db = getDb(pg.url);
 
 app.route('/api/auth', authRoute({ db }));
 app.route('/api/agents', agentsRoute({ db }));
+app.route('/api/conversations', conversationsRoute({ db }));
+app.route(
+  '/widget',
+  widgetRoute({
+    db,
+    sessionRoot,
+    // Deterministic stub for E2E so the test doesn't need network access or
+    // an Anthropic API key. Production wires the real worker pool in index.ts.
+    invokeAgent: async (_options, history) => {
+      const last = history[history.length - 1];
+      return `Echo: ${last?.content ?? ''}`;
+    },
+  }),
+);
 mountStatic(app);
 
 const server = Bun.serve({ port, fetch: app.fetch });

--- a/apps/web/public/widget-test.html
+++ b/apps/web/public/widget-test.html
@@ -1,0 +1,28 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <title>Nexus widget test page</title>
+  </head>
+  <body>
+    <h1 data-testid="widget-test-page">Nexus widget test page</h1>
+    <p>Embed below.</p>
+    <script>
+      // The E2E test passes ?channelId=<uuid> in the URL. The script tag is
+      // injected here so its data-channel-id lines up with the active channel.
+      var channelId = new URLSearchParams(location.search).get('channelId');
+      if (channelId) {
+        var s = document.createElement('script');
+        s.src = '/widget.js';
+        s.setAttribute('data-channel-id', channelId);
+        document.body.appendChild(s);
+      } else {
+        document.body.appendChild(
+          Object.assign(document.createElement('p'), {
+            textContent: 'pass ?channelId=<uuid> to embed the widget',
+          }),
+        );
+      }
+    </script>
+  </body>
+</html>

--- a/apps/web/public/widget.js
+++ b/apps/web/public/widget.js
@@ -1,0 +1,108 @@
+// Embeddable Nexus widget SDK.
+//
+// Usage:
+//   <script src="/widget.js" data-channel-id="<uuid>"></script>
+//
+// The script reads its data-channel-id, generates a per-tab widget session id
+// (kept in sessionStorage so a tab refresh keeps the same conversation), and
+// renders a fixed-position chat panel that POSTs to /widget/messages.
+//
+// Plain JS, no framework — this is what a third-party site embeds.
+(function () {
+  var script = document.currentScript;
+  var channelId = script && script.getAttribute('data-channel-id');
+  var apiBase = (script && script.getAttribute('data-api-base')) || '';
+  if (!channelId) {
+    console.warn('[nexus-widget] missing data-channel-id');
+    return;
+  }
+
+  var sessionKey = 'nexus.widget.session.' + channelId;
+  var widgetSessionId = sessionStorage.getItem(sessionKey);
+  if (!widgetSessionId) {
+    widgetSessionId = 'w-' + Math.random().toString(36).slice(2) + Date.now().toString(36);
+    sessionStorage.setItem(sessionKey, widgetSessionId);
+  }
+
+  var root = document.createElement('div');
+  root.setAttribute('data-testid', 'nexus-widget');
+  root.style.cssText =
+    'position:fixed;bottom:16px;right:16px;width:320px;max-height:480px;display:flex;flex-direction:column;font-family:system-ui,sans-serif;background:#0f172a;color:#e2e8f0;border:1px solid #1e293b;border-radius:12px;box-shadow:0 10px 30px rgba(0,0,0,0.35);z-index:2147483647;';
+
+  var header = document.createElement('div');
+  header.textContent = 'Chat';
+  header.style.cssText = 'padding:10px 14px;border-bottom:1px solid #1e293b;font-weight:600;';
+  root.appendChild(header);
+
+  var log = document.createElement('div');
+  log.setAttribute('data-testid', 'nexus-widget-log');
+  log.style.cssText = 'flex:1;overflow:auto;padding:10px 14px;display:flex;flex-direction:column;gap:8px;';
+  root.appendChild(log);
+
+  var form = document.createElement('form');
+  form.style.cssText = 'display:flex;gap:8px;padding:10px;border-top:1px solid #1e293b;';
+  var input = document.createElement('input');
+  input.type = 'text';
+  input.placeholder = 'Type a message…';
+  input.setAttribute('data-testid', 'nexus-widget-input');
+  input.style.cssText =
+    'flex:1;background:#020617;color:#f8fafc;border:1px solid #1e293b;border-radius:6px;padding:6px 10px;font:inherit;';
+  var button = document.createElement('button');
+  button.type = 'submit';
+  button.textContent = 'Send';
+  button.setAttribute('data-testid', 'nexus-widget-send');
+  button.style.cssText =
+    'background:#22c55e;color:#020617;border:0;border-radius:6px;padding:6px 12px;font:inherit;font-weight:600;cursor:pointer;';
+  form.appendChild(input);
+  form.appendChild(button);
+  root.appendChild(form);
+  document.body.appendChild(root);
+
+  function append(role, content) {
+    var bubble = document.createElement('div');
+    bubble.setAttribute('data-role', role);
+    bubble.setAttribute('data-testid', 'nexus-widget-message-' + role);
+    bubble.textContent = content;
+    bubble.style.cssText =
+      'padding:6px 10px;border-radius:8px;max-width:88%;word-wrap:break-word;' +
+      (role === 'user'
+        ? 'align-self:flex-end;background:#1e40af;color:#f8fafc;'
+        : 'align-self:flex-start;background:#1e293b;color:#e2e8f0;');
+    log.appendChild(bubble);
+    log.scrollTop = log.scrollHeight;
+  }
+
+  form.addEventListener('submit', function (e) {
+    e.preventDefault();
+    var content = input.value.trim();
+    if (!content) return;
+    append('user', content);
+    input.value = '';
+    input.disabled = true;
+    button.disabled = true;
+    fetch(apiBase + '/widget/messages', {
+      method: 'POST',
+      headers: { 'content-type': 'application/json' },
+      body: JSON.stringify({
+        channelId: channelId,
+        widgetSessionId: widgetSessionId,
+        content: content,
+      }),
+    })
+      .then(function (r) {
+        if (!r.ok) throw new Error('widget message failed: ' + r.status);
+        return r.json();
+      })
+      .then(function (body) {
+        append('assistant', body.reply);
+      })
+      .catch(function (err) {
+        append('assistant', '[error: ' + err.message + ']');
+      })
+      .finally(function () {
+        input.disabled = false;
+        button.disabled = false;
+        input.focus();
+      });
+  });
+})();

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Navigate, Outlet, Route, Routes } from 'react-router-dom
 import { AuthProvider, useAuth } from './auth/auth';
 import { AppShell } from './layout/AppShell';
 import { Agents } from './pages/Agents';
+import { Conversations } from './pages/Conversations';
 import { Dashboard } from './pages/Dashboard';
 import { Login } from './pages/Login';
 import { Register } from './pages/Register';
@@ -17,6 +18,7 @@ export function App() {
             <Route element={<AppShell />}>
               <Route index element={<Dashboard />} />
               <Route path="/agents" element={<Agents />} />
+              <Route path="/conversations" element={<Conversations />} />
             </Route>
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -12,6 +12,7 @@ export function AppShell() {
         <nav className="mt-4 space-y-1 text-sm">
           <SideLink to="/" label="Dashboard" />
           <SideLink to="/agents" label="Agents" />
+          <SideLink to="/conversations" label="Conversations" />
         </nav>
         <div className="mt-auto pt-4 border-t border-zinc-800 text-xs text-zinc-400">
           <div data-testid="signed-in-as" className="px-2 truncate">

--- a/apps/web/src/pages/Agents.tsx
+++ b/apps/web/src/pages/Agents.tsx
@@ -7,6 +7,7 @@ export type Agent = {
   model: string;
   runtimeMode: 'headless' | 'dedicated';
   voiceEnabled: boolean;
+  widgetChannelId: string | null;
 };
 
 type FormDraft = {
@@ -282,6 +283,14 @@ function AgentList({
             <div className="truncate text-xs text-zinc-400">
               {a.model} · voice {a.voiceEnabled ? 'on' : 'off'}
             </div>
+            {a.widgetChannelId && (
+              <div
+                data-testid={`agent-widget-channel-${a.id}`}
+                className="mt-1 truncate font-mono text-[10px] text-zinc-500"
+              >
+                widget: {a.widgetChannelId}
+              </div>
+            )}
           </div>
           <div className="flex gap-2">
             <button

--- a/apps/web/src/pages/Conversations.tsx
+++ b/apps/web/src/pages/Conversations.tsx
@@ -1,0 +1,134 @@
+// Operator-facing basic conversation view. Lists agent sessions for the org;
+// clicking one shows its messages. The full timeline lands in #28.
+
+import { useCallback, useEffect, useState } from 'react';
+
+type ConversationSummary = {
+  id: string;
+  agentName: string;
+  channelKind: string;
+  createdAt: string;
+};
+
+type Message = {
+  sequence: number;
+  role: 'user' | 'assistant' | 'system';
+  content: string;
+  createdAt: string;
+};
+
+type ConversationDetail = ConversationSummary & {
+  messages: Message[];
+};
+
+export function Conversations() {
+  const [list, setList] = useState<ConversationSummary[] | null>(null);
+  const [selected, setSelected] = useState<ConversationDetail | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const refresh = useCallback(async () => {
+    setError(null);
+    try {
+      const res = await fetch('/api/conversations', { credentials: 'same-origin' });
+      if (!res.ok) throw new Error(`Failed to load conversations (${res.status})`);
+      const body = (await res.json()) as { conversations: ConversationSummary[] };
+      setList(body.conversations);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load conversations.');
+    }
+  }, []);
+
+  const open = useCallback(async (id: string) => {
+    setError(null);
+    try {
+      const res = await fetch(`/api/conversations/${id}`, { credentials: 'same-origin' });
+      if (!res.ok) throw new Error(`Failed to load conversation (${res.status})`);
+      const body = (await res.json()) as { conversation: ConversationDetail };
+      setSelected(body.conversation);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load conversation.');
+    }
+  }, []);
+
+  useEffect(() => {
+    void refresh();
+    // Auto-refresh so the new widget conversation shows up without a manual reload.
+    const t = setInterval(() => void refresh(), 2000);
+    return () => clearInterval(t);
+  }, [refresh]);
+
+  return (
+    <section data-testid="conversations-page" className="space-y-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold tracking-tight">Conversations</h1>
+        <button
+          type="button"
+          onClick={() => void refresh()}
+          className="rounded-md border border-zinc-700 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-800"
+        >
+          Refresh
+        </button>
+      </header>
+
+      {error && (
+        <p role="alert" className="text-sm text-red-400">
+          {error}
+        </p>
+      )}
+
+      <div className="grid grid-cols-3 gap-4">
+        <ul
+          data-testid="conversations-list"
+          className="col-span-1 divide-y divide-zinc-800 rounded-lg border border-zinc-800"
+        >
+          {(list ?? []).length === 0 && (
+            <li
+              data-testid="conversations-empty"
+              className="px-4 py-3 text-sm text-zinc-400"
+            >
+              No conversations yet.
+            </li>
+          )}
+          {(list ?? []).map((c) => (
+            <li key={c.id}>
+              <button
+                type="button"
+                onClick={() => void open(c.id)}
+                data-testid={`conversation-row-${c.id}`}
+                className="flex w-full items-start justify-between px-4 py-3 text-left hover:bg-zinc-800/40"
+              >
+                <span className="text-sm">
+                  <span className="text-zinc-100">{c.agentName}</span>
+                  <span className="ml-2 text-xs text-zinc-400">{c.channelKind}</span>
+                </span>
+              </button>
+            </li>
+          ))}
+        </ul>
+
+        <div
+          data-testid="conversation-detail"
+          className="col-span-2 rounded-lg border border-zinc-800 p-4 space-y-2"
+        >
+          {!selected && (
+            <p className="text-sm text-zinc-400">Select a conversation to view messages.</p>
+          )}
+          {selected?.messages.map((m) => (
+            <div
+              key={m.sequence}
+              data-testid={`conversation-message-${m.role}`}
+              className={
+                m.role === 'user'
+                  ? 'rounded-md bg-blue-900/40 px-3 py-2 text-sm text-zinc-100'
+                  : 'rounded-md bg-zinc-800 px-3 py-2 text-sm text-zinc-100'
+              }
+            >
+              <span className="block text-xs text-zinc-400">{m.role}</span>
+              {m.content}
+            </div>
+          ))}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,10 +19,11 @@ export default defineConfig({
     { name: 'chromium', use: { ...devices['Desktop Chrome'] } },
   ],
   webServer: {
-    // Boots a Postgres container, runs migrations, and serves auth API + Vite dist on PORT.
-    command: `bun run apps/server/src/test-helpers/e2e-server.ts`,
+    // Builds the web app, then boots a Postgres container, runs migrations,
+    // and serves the API + built dist on PORT.
+    command: `bun run --filter @nexus/web build && bun run apps/server/src/test-helpers/e2e-server.ts`,
     url: BASE_URL,
-    timeout: 120_000,
+    timeout: 180_000,
     reuseExistingServer: false,
     stdout: 'pipe',
     stderr: 'pipe',

--- a/tests/e2e/widget.spec.ts
+++ b/tests/e2e/widget.spec.ts
@@ -1,0 +1,64 @@
+import { test, expect } from '@playwright/test';
+
+// First end-to-end: a JS widget on a test page sends a message to the
+// headless runtime, the runtime replies, the widget renders the reply, and
+// the operator UI shows the same conversation.
+
+test('widget chat: send "hello" → see agent reply in widget AND in operator UI', async ({
+  browser,
+}) => {
+  // 1. Operator registers and creates an agent (which auto-provisions a
+  //    widget channel).
+  const operatorContext = await browser.newContext();
+  const operator = await operatorContext.newPage();
+  const email = `op+widget+${Date.now()}@example.com`;
+  const password = 'hunter2hunter2';
+
+  await operator.goto('/register');
+  await operator.getByLabel('Email').fill(email);
+  await operator.getByLabel('Password (8+ characters)').fill(password);
+  await operator.getByRole('button', { name: 'Create account' }).click();
+  await expect(operator.getByTestId('dashboard')).toBeVisible();
+
+  await operator.getByRole('link', { name: 'Agents' }).click();
+  await operator.getByRole('button', { name: 'New agent' }).click();
+  await operator.getByLabel('Name').fill('Widget Bot');
+  await operator.getByLabel('Persona').fill('Cheerfully echo whatever a visitor says.');
+  await operator.getByLabel('Model').fill('claude-haiku-test');
+  await operator.getByRole('button', { name: 'Create agent' }).click();
+
+  const widgetSlot = operator.getByTestId(/^agent-widget-channel-/);
+  await expect(widgetSlot).toBeVisible();
+  const widgetText = (await widgetSlot.textContent()) ?? '';
+  const channelId = widgetText.replace(/^widget:\s*/, '').trim();
+  expect(channelId).toMatch(/^[0-9a-f-]{36}$/);
+
+  // 2. Visitor (separate browser context — different sessionStorage, different
+  //    auth) loads the test page with the channel id and uses the widget.
+  const visitorContext = await browser.newContext();
+  const visitor = await visitorContext.newPage();
+  await visitor.goto(`/widget-test.html?channelId=${channelId}`);
+  await expect(visitor.getByTestId('widget-test-page')).toBeVisible();
+
+  await expect(visitor.getByTestId('nexus-widget')).toBeVisible();
+  await visitor.getByTestId('nexus-widget-input').fill('hello');
+  await visitor.getByTestId('nexus-widget-send').click();
+
+  // Visitor sees their own message and the agent's reply.
+  await expect(visitor.getByTestId('nexus-widget-message-user')).toHaveText('hello');
+  await expect(visitor.getByTestId('nexus-widget-message-assistant')).toHaveText(/Echo: hello/);
+
+  // 3. Operator switches to Conversations and sees the same conversation.
+  await operator.getByRole('link', { name: 'Conversations' }).click();
+  await expect(operator.getByTestId('conversations-page')).toBeVisible();
+
+  const row = operator.getByTestId(/^conversation-row-/);
+  await expect(row.first()).toBeVisible();
+  await row.first().click();
+
+  await expect(operator.getByTestId('conversation-message-user')).toContainText('hello');
+  await expect(operator.getByTestId('conversation-message-assistant')).toContainText('Echo: hello');
+
+  await operatorContext.close();
+  await visitorContext.close();
+});


### PR DESCRIPTION
First user-visible end-to-end behavior: a JS widget on a test page sends a message to a headless agent and gets a reply, visible in both the widget and the operator UI.

## What's in

**Schema (Drizzle, migration 0004)**: `channel`, `contact`, `identifier` (with `do_not_contact` flag), `agent_session`, `agent_message` (append-only via unique index on `(session_id, sequence)`). Named `agent_session` / `agent_message` because `session` is already the operator HTTP-auth table — disambiguating those felt safer than colliding.

**Headless runtime (`apps/server/src/headless/`)**: 
- `materialize.ts` — fresh per-session SDK working dir; ancestor-sanitation refuses to materialize if any walk-up ancestor has `.claude/`, `.mcp.json`, or `CLAUDE.md`.
- `sdk-options.ts` — single construction path; `settingSources: ['project']` is hard-coded and unit-tested.
- `session-store.ts` — append-only writes; an `appendAt` test seam proves out-of-order writes fail fast.
- `worker-pool.ts` — one Bun Worker per active session; an uncaught error inside a worker terminates only that worker, and the next dispatch on that session id spawns a fresh one.
- `runtime.ts` — single resolver: identifier → contact → session → invoke → persist. Outbound message-send (#10) will reuse `resolveSession` and `runTurn` directly.
- `worker.ts` — Bun Worker entry. Currently runs a deterministic echo (no `@anthropic-ai/claude-agent-sdk` in the monorepo yet); the SDK call site is one function swap.

**Endpoints**:
- `POST /widget/messages` — public widget inbound. Validates body, confirms the channel is a widget channel, dispatches.
- `GET /api/conversations`, `GET /api/conversations/:id` — operator-scoped read API for the basic conversation view (full timeline lands in #28).
- Agent create now auto-provisions a widget channel for the agent and returns its id alongside the agent.

**UI**:
- `apps/web/public/widget.js` — plain-JS embed, reads `data-channel-id`, generates a per-tab widget session id (sessionStorage), renders a fixed-position chat panel, POSTs to `/widget/messages`.
- `apps/web/public/widget-test.html` — test page that injects the widget script with `?channelId=<uuid>` from the URL.
- `apps/web/src/pages/Conversations.tsx` — operator conversation view: list + detail.
- Agent rows surface the auto-provisioned widget channel id so the operator can copy it.

**Tests** (TDD, no internal mocks, real Postgres test container):
- `sdk-options.test.ts` — pins `settingSources: ['project']` even when callers ask for `user`.
- `materialize.test.ts` — happy path + ancestor-sanitation refuses to materialize when an ancestor carries `.claude/`, `.mcp.json`, or `CLAUDE.md`.
- `session-store.test.ts` — monotonic sequences, list-in-order, out-of-order rejected.
- `runtime.test.ts` — first-message lookup-or-create, returning-visitor reuses session, full-history reaches the agent, every turn carries project-only settings + the per-session cwd.
- `worker-pool.test.ts` — dispatch round-trip, same-session reuse, structured error surfaces, after-crash recovery via a marker-file branch in the worker.
- `widget.test.ts` — endpoint validation + dispatch.
- `conversations.test.ts` — operator scope check.
- `tests/e2e/widget.spec.ts` — operator creates an agent → visitor (separate browser context) loads `/widget-test.html?channelId=...` → sends "hello" → sees the reply in the widget AND in the operator's Conversations view.

48 server unit/integration tests pass; 3 Playwright e2e tests pass.

## Naming note

The acceptance criteria call the conversation tables `session` / `message`. They're named `agent_session` / `agent_message` here because the existing operator HTTP auth uses the `session` table. Internal-to-the-slice naming decision; the API still calls them conversations.

Closes #7