### PR TITLE
ci: add typecheck workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,17 @@
+name: ci
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+jobs:
+  typecheck:
+    name: typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - run: bun install --frozen-lockfile
+      - run: bun run typecheck


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` running `bun install` + `bun run typecheck` on every PR and push to main.
- Needed so branch protection on `main` has a real status check to gate auto-merge against — without this, `gh pr merge --auto` fails with `Protected branch rules not configured`.

## Test plan
- [ ] CI workflow runs on this PR and passes (typecheck is currently green locally).
- [ ] After merge, branch protection on `main` will be added requiring the `typecheck` check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)