### PR TITLE
Slice 10: Email via Mailtrap

### DIFF
--- a/apps/server/drizzle/0005_email_channel.sql
+++ b/apps/server/drizzle/0005_email_channel.sql
@@ -1,0 +1,21 @@
+-- Email channel: extends `channel` with kind-specific columns, adds an inbound
+-- dedupe table for poll-based ingestion, and adds `external_id` to
+-- `agent_message` for email threading (Message-ID).
+
+ALTER TABLE "channel" ADD COLUMN IF NOT EXISTS "email_address" text;--> statement-breakpoint
+ALTER TABLE "channel" ADD COLUMN IF NOT EXISTS "mailtrap_inbox_id" text;--> statement-breakpoint
+ALTER TABLE "agent_message" ADD COLUMN IF NOT EXISTS "external_id" text;--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "channel_inbound_seen" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"channel_id" uuid NOT NULL,
+	"external_id" text NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "channel_inbound_seen" ADD CONSTRAINT "channel_inbound_seen_channel_id_channel_id_fk" FOREIGN KEY ("channel_id") REFERENCES "public"."channel"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE UNIQUE INDEX IF NOT EXISTS "channel_inbound_seen_channel_external_unique" ON "channel_inbound_seen" USING btree ("channel_id","external_id");

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -36,6 +36,13 @@
       "when": 1777500000000,
       "tag": "0004_widget_channel",
       "breakpoints": true
+    },
+    {
+      "idx": 5,
+      "version": "7",
+      "when": 1777600000000,
+      "tag": "0005_email_channel",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -15,18 +15,14 @@
     "@nexus/logger": "workspace:*",
     "drizzle-orm": "^0.36.4",
     "hono": "^4.6.12",
-    "mailparser": "^3.9.8",
     "minio": "^8.0.2",
     "nodemailer": "^8.0.7",
     "postgres": "^3.4.5",
-    "smtp-server": "^3.18.4",
     "valibot": "^1.0.0-beta.9"
   },
   "devDependencies": {
     "@types/bun": "^1.1.17",
-    "@types/mailparser": "^3.4.6",
     "@types/nodemailer": "^8.0.0",
-    "@types/smtp-server": "^3.5.13",
     "drizzle-kit": "^0.28.1",
     "typescript": "^5.6.3"
   }

--- a/apps/server/package.json
+++ b/apps/server/package.json
@@ -13,15 +13,21 @@
   },
   "dependencies": {
     "@nexus/logger": "workspace:*",
-    "hono": "^4.6.12",
     "drizzle-orm": "^0.36.4",
+    "hono": "^4.6.12",
+    "mailparser": "^3.9.8",
+    "minio": "^8.0.2",
+    "nodemailer": "^8.0.7",
     "postgres": "^3.4.5",
-    "valibot": "^1.0.0-beta.9",
-    "minio": "^8.0.2"
+    "smtp-server": "^3.18.4",
+    "valibot": "^1.0.0-beta.9"
   },
   "devDependencies": {
+    "@types/bun": "^1.1.17",
+    "@types/mailparser": "^3.4.6",
+    "@types/nodemailer": "^8.0.0",
+    "@types/smtp-server": "^3.5.13",
     "drizzle-kit": "^0.28.1",
-    "typescript": "^5.6.3",
-    "@types/bun": "^1.1.17"
+    "typescript": "^5.6.3"
   }
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -88,6 +88,11 @@ export const agent = pgTable('agent', {
 // Channel: an addressable surface (one row per agent×channel binding). For the
 // widget, every agent installation has its own channel row; later channels
 // (SMS, voice, etc.) follow the same pattern.
+//
+// Email-specific columns (`emailAddress`, `mailtrapInboxId`) live here as
+// nullable: the widget kind doesn't need them, and adding a side-table for
+// kind-specific config is overkill for the small set of fields the email
+// channel needs in this slice.
 export const channel = pgTable('channel', {
   id: uuid('id').primaryKey().defaultRandom(),
   orgId: uuid('org_id')
@@ -97,6 +102,8 @@ export const channel = pgTable('channel', {
   agentId: uuid('agent_id')
     .notNull()
     .references(() => agent.id, { onDelete: 'cascade' }),
+  emailAddress: text('email_address'),
+  mailtrapInboxId: text('mailtrap_inbox_id'),
   createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
 });
 
@@ -153,6 +160,9 @@ export const agentSession = pgTable('agent_session', {
 // Agent message: append-only log of turns within a session. PRD invariant #5
 // requires monotonic, gap-free sequence numbers — enforced in session-store.ts
 // and pinned by a unique index on (session, sequence).
+//
+// `externalId` carries the channel-specific message id used for threading
+// (e.g. an email Message-ID). Nullable because not every channel needs it.
 export const agentMessage = pgTable(
   'agent_message',
   {
@@ -163,12 +173,34 @@ export const agentMessage = pgTable(
     sequence: integer('sequence').notNull(),
     role: messageRole('role').notNull(),
     content: text('content').notNull(),
+    externalId: text('external_id'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },
   (t) => ({
     sessionSequenceUnique: uniqueIndex('agent_message_session_sequence_unique').on(
       t.sessionId,
       t.sequence,
+    ),
+  }),
+);
+
+// Inbound dedupe for poll-based channels. The email poller writes one row per
+// (channel, mailtrap message id) so a re-poll doesn't re-dispatch a message
+// already handled. Unique index makes the insert idempotent.
+export const channelInboundSeen = pgTable(
+  'channel_inbound_seen',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    channelId: uuid('channel_id')
+      .notNull()
+      .references(() => channel.id, { onDelete: 'cascade' }),
+    externalId: text('external_id').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    channelExternalUnique: uniqueIndex('channel_inbound_seen_channel_external_unique').on(
+      t.channelId,
+      t.externalId,
     ),
   }),
 );

--- a/apps/server/src/headless/runtime.ts
+++ b/apps/server/src/headless/runtime.ts
@@ -137,6 +137,33 @@ export function createHeadlessRuntime({ db, sessionRoot, invokeAgent }: Deps) {
     return reply;
   }
 
+  // Materialize the SDK cwd, build the SDK options, invoke the agent over
+  // the session's full message history, and return the reply text. Does NOT
+  // append the result — callers that need to attach channel-specific metadata
+  // (e.g. an email Message-ID) to the assistant turn handle persistence
+  // themselves.
+  async function invokeOverHistory(resolved: {
+    sessionId: string;
+    persona: string;
+    model: string;
+  }): Promise<string> {
+    const materialized = await materializeSession({
+      sessionRoot,
+      sessionId: resolved.sessionId,
+      skills: [],
+      subagents: [],
+    });
+    const options = buildSdkOptions({
+      cwd: materialized.cwd,
+      model: resolved.model,
+      persona: resolved.persona,
+    });
+    const history = (await store.list(resolved.sessionId)).map(
+      (m): AgentTurn => ({ role: m.role, content: m.content }),
+    );
+    return invokeAgent(options, history);
+  }
+
   return {
     async handleInbound(args: InboundArgs): Promise<InboundResult> {
       const { sessionId, persona, model } = await resolveSession(args);
@@ -148,7 +175,12 @@ export function createHeadlessRuntime({ db, sessionRoot, invokeAgent }: Deps) {
       return store.list(sessionId);
     },
 
-    // Exposed so future code (outbound send in #10) can share the resolver.
+    // Exposed so the outbound path (e.g. email channel) can share the
+    // resolver — invariant #10.
     resolveSession,
+
+    // Exposed for channels that handle their own persistence (e.g. email,
+    // which carries an external Message-ID on every turn).
+    invokeOverHistory,
   };
 }

--- a/apps/server/src/headless/session-store.ts
+++ b/apps/server/src/headless/session-store.ts
@@ -16,6 +16,9 @@ import { agentMessage } from '../db/schema.ts';
 export type MessageInput = {
   role: 'user' | 'assistant' | 'system';
   content: string;
+  // Channel-specific message id used for threading (e.g. an email Message-ID).
+  // Optional because not every channel uses one.
+  externalId?: string | undefined;
 };
 
 export type StoredMessage = MessageInput & {
@@ -54,7 +57,13 @@ export function createSessionStore({ db }: Deps): SessionStore {
       const sequence = await nextSequence(sessionId);
       const [stored] = await db
         .insert(agentMessage)
-        .values({ sessionId, sequence, role: msg.role, content: msg.content })
+        .values({
+          sessionId,
+          sequence,
+          role: msg.role,
+          content: msg.content,
+          externalId: msg.externalId,
+        })
         .returning();
       return toApi(stored!);
     },
@@ -68,7 +77,13 @@ export function createSessionStore({ db }: Deps): SessionStore {
       }
       const [stored] = await db
         .insert(agentMessage)
-        .values({ sessionId, sequence, role: msg.role, content: msg.content })
+        .values({
+          sessionId,
+          sequence,
+          role: msg.role,
+          content: msg.content,
+          externalId: msg.externalId,
+        })
         .returning();
       return toApi(stored!);
     },
@@ -90,6 +105,7 @@ function toApi(row: typeof agentMessage.$inferSelect): StoredMessage {
     sequence: row.sequence,
     role: row.role,
     content: row.content,
+    externalId: row.externalId ?? undefined,
     createdAt: row.createdAt,
   };
 }

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -14,6 +14,7 @@ import { authRoute } from './routes/auth.ts';
 import { agentsRoute } from './routes/agents.ts';
 import { widgetRoute } from './routes/widget.ts';
 import { conversationsRoute } from './routes/conversations.ts';
+import { emailRoute } from './routes/email.ts';
 import { createWorkerPool } from './headless/worker-pool.ts';
 
 const env = loadEnv();
@@ -24,7 +25,10 @@ await ensureBucket(env);
 const db = getDb(env.DATABASE_URL);
 // Instantiating here surfaces a bad CREDENTIAL_ENCRYPTION_KEY at startup
 // rather than on first credential write.
-createCredentialService({ db, encryptionKey: env.CREDENTIAL_ENCRYPTION_KEY });
+const credentials = createCredentialService({
+  db,
+  encryptionKey: env.CREDENTIAL_ENCRYPTION_KEY,
+});
 
 // Per-session SDK working directories live under sessionRoot. Its ancestors
 // are the runtime data dir and the project root — neither contains SDK
@@ -43,6 +47,7 @@ app.route('/healthz', healthRoute({ env, db }));
 app.route('/api/auth', authRoute({ db }));
 app.route('/api/agents', agentsRoute({ db }));
 app.route('/api/conversations', conversationsRoute({ db }));
+app.route('/api/email', emailRoute({ db, credentials }));
 app.route(
   '/widget',
   widgetRoute({

--- a/apps/server/src/mail/client.ts
+++ b/apps/server/src/mail/client.ts
@@ -1,0 +1,133 @@
+// Mailtrap client: thin wrapper over the two operations the email channel
+// needs from Mailtrap.
+//
+//   1. List/fetch messages from a sandbox inbox (HTTP API).
+//   2. Send mail through Mailtrap's SMTP.
+//
+// The interface is small on purpose — the rest of the email-channel code
+// depends on this shape, not on nodemailer or fetch directly. An in-memory
+// implementation lives next to it for integration tests.
+
+import nodemailer from 'nodemailer';
+
+export type MailtrapInboundMessage = {
+  id: string;
+  from: string;
+  to: string;
+  subject: string;
+  text: string;
+  // RFC 5322 Message-ID of the message we received. Used as the agent_message
+  // external_id and as the In-Reply-To value when we reply.
+  messageId: string;
+  // The Message-ID this message was a reply to, if any. Used to thread
+  // operator replies into the same agent session as our outbound (PRD #10).
+  inReplyTo?: string | undefined;
+  references?: string[] | undefined;
+};
+
+export type SendMailArgs = {
+  from: string;
+  to: string;
+  subject: string;
+  text: string;
+  // The Message-ID we set on the outgoing email. Caller controls this so the
+  // agent_message row and the wire-level header match exactly.
+  messageId: string;
+  inReplyTo?: string | undefined;
+  references?: string[] | undefined;
+};
+
+export type MailtrapClient = {
+  listMessages(inboxId: string): Promise<MailtrapInboundMessage[]>;
+  sendMail(args: SendMailArgs): Promise<void>;
+};
+
+export type MailtrapHttpConfig = {
+  apiToken: string;
+  accountId: string;
+  // sandbox.api.mailtrap.io for the testing/sandbox API. Configurable so tests
+  // can point at a local fake.
+  apiBase?: string;
+};
+
+export type MailtrapSmtpConfig = {
+  host: string;
+  port: number;
+  user: string;
+  pass: string;
+};
+
+// Real Mailtrap implementation. List uses the sandbox HTTP API; send uses
+// nodemailer over SMTP.
+export function createMailtrapClient(config: {
+  http: MailtrapHttpConfig;
+  smtp: MailtrapSmtpConfig;
+}): MailtrapClient {
+  const apiBase = config.http.apiBase ?? 'https://sandbox.api.mailtrap.io';
+  const transporter = nodemailer.createTransport({
+    host: config.smtp.host,
+    port: config.smtp.port,
+    auth: { user: config.smtp.user, pass: config.smtp.pass },
+  });
+
+  return {
+    async listMessages(inboxId) {
+      const url = `${apiBase}/api/accounts/${config.http.accountId}/inboxes/${inboxId}/messages`;
+      const res = await fetch(url, {
+        headers: {
+          'Api-Token': config.http.apiToken,
+          accept: 'application/json',
+        },
+      });
+      if (!res.ok) {
+        throw new Error(`mailtrap list ${res.status}: ${await res.text()}`);
+      }
+      const rows = (await res.json()) as Array<{
+        id: number;
+        from_email: string;
+        to_email: string;
+        subject: string;
+        text_body?: string;
+        message_id?: string;
+        in_reply_to?: string;
+        references?: string[];
+      }>;
+      // Sandbox API returns rows without bodies; fetch the full body per row.
+      const messages: MailtrapInboundMessage[] = [];
+      for (const row of rows) {
+        const bodyUrl = `${apiBase}/api/accounts/${config.http.accountId}/inboxes/${inboxId}/messages/${row.id}/body.txt`;
+        const bodyRes = await fetch(bodyUrl, {
+          headers: { 'Api-Token': config.http.apiToken },
+        });
+        const text = bodyRes.ok ? await bodyRes.text() : (row.text_body ?? '');
+        messages.push({
+          id: String(row.id),
+          from: row.from_email,
+          to: row.to_email,
+          subject: row.subject,
+          text,
+          messageId: row.message_id ?? `mailtrap-${row.id}`,
+          inReplyTo: row.in_reply_to,
+          references: row.references,
+        });
+      }
+      return messages;
+    },
+
+    async sendMail(args) {
+      const headers: Record<string, string> = {};
+      if (args.inReplyTo) headers['In-Reply-To'] = args.inReplyTo;
+      if (args.references && args.references.length > 0) {
+        headers['References'] = args.references.join(' ');
+      }
+      await transporter.sendMail({
+        from: args.from,
+        to: args.to,
+        subject: args.subject,
+        text: args.text,
+        messageId: args.messageId,
+        headers,
+      });
+    },
+  };
+}

--- a/apps/server/src/mail/email-channel.test.ts
+++ b/apps/server/src/mail/email-channel.test.ts
@@ -1,0 +1,189 @@
+// Email channel integration tests.
+//
+// Test 1 (inbound): a customer email arrives in the channel's Mailtrap inbox
+//   → poll picks it up → agent replies → reply lands in the same inbox via
+//   SMTP. Asserts the AC "send inbound email via Mailtrap test inbox → agent
+//   replies → reply lands in Mailtrap test inbox".
+//
+// Test 2 (threading, invariant #10): an outbound-first send to a contact, then
+//   the contact replies. Both turns must land in the same agent_session and
+//   share the same email thread (In-Reply-To/References chain).
+
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { sql } from 'drizzle-orm';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { agent, channel, org } from '../db/schema.ts';
+import { createHeadlessRuntime } from '../headless/runtime.ts';
+import { createFakeMailtrapClient, type FakeMailtrapClient } from './fake-client.ts';
+import { createEmailChannel } from './email-channel.ts';
+
+let pg: StartedPg;
+let sessionRoot: string;
+const INBOX_ID = 'inbox-1';
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+  sessionRoot = await mkdtemp(join(tmpdir(), 'nexus-email-rt-'));
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+  await rm(sessionRoot, { recursive: true, force: true });
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(
+    sql`TRUNCATE TABLE "channel_inbound_seen", "agent_message", "agent_session", "identifier", "contact", "channel", "agent", "session", "user", "org" RESTART IDENTITY CASCADE`,
+  );
+});
+
+async function seedEmailChannel(): Promise<{
+  channelId: string;
+  emailAddress: string;
+}> {
+  const db = getDb(pg.url);
+  const [o] = await db.insert(org).values({ name: 'o' }).returning();
+  const [a] = await db
+    .insert(agent)
+    .values({ orgId: o!.id, name: 'a', persona: 'p', model: 'm' })
+    .returning();
+  const emailAddress = 'agent@nexus.test';
+  const [ch] = await db
+    .insert(channel)
+    .values({
+      orgId: o!.id,
+      kind: 'email',
+      agentId: a!.id,
+      emailAddress,
+      mailtrapInboxId: INBOX_ID,
+    })
+    .returning();
+  return { channelId: ch!.id, emailAddress };
+}
+
+function buildHarness(client: FakeMailtrapClient) {
+  const db = getDb(pg.url);
+  const runtime = createHeadlessRuntime({
+    db,
+    sessionRoot,
+    invokeAgent: async (_options, history) => {
+      const last = history[history.length - 1]!;
+      return `Echo: ${last.content}`;
+    },
+  });
+  return createEmailChannel({ db, client, runtime });
+}
+
+test('inbound email → agent reply → reply lands in the inbox', async () => {
+  const { channelId, emailAddress } = await seedEmailChannel();
+  const client = createFakeMailtrapClient({ sendInboxId: INBOX_ID });
+  const channel = buildHarness(client);
+
+  client.injectInbound(INBOX_ID, {
+    from: 'visitor@example.com',
+    to: emailAddress,
+    subject: 'Hi there',
+    text: 'hello',
+    messageId: '<visitor-1@example.com>',
+  });
+
+  await channel.pollChannel(channelId);
+
+  const inbox = client.inboxSnapshot(INBOX_ID);
+  // The injected inbound + the assistant's outbound reply.
+  expect(inbox.length).toBe(2);
+  const reply = inbox.find((m) => m.from === emailAddress);
+  expect(reply).toBeDefined();
+  expect(reply!.to).toBe('visitor@example.com');
+  expect(reply!.text).toBe('Echo: hello');
+  expect(reply!.subject).toBe('Re: Hi there');
+  expect(reply!.inReplyTo).toBe('<visitor-1@example.com>');
+  expect(reply!.references).toContain('<visitor-1@example.com>');
+});
+
+test('repeat poll does not re-dispatch the same inbound message', async () => {
+  const { channelId, emailAddress } = await seedEmailChannel();
+  const client = createFakeMailtrapClient({ sendInboxId: INBOX_ID });
+  const channel = buildHarness(client);
+
+  client.injectInbound(INBOX_ID, {
+    from: 'visitor@example.com',
+    to: emailAddress,
+    subject: 'Hi',
+    text: 'hello',
+    messageId: '<visitor-1@example.com>',
+  });
+
+  await channel.pollChannel(channelId);
+  await channel.pollChannel(channelId);
+
+  // First poll: inbound + assistant reply = 2.
+  // Second poll sees the assistant's outbound (skipped: from === channel
+  // address) and the original inbound (dedup hit). No new mail.
+  const inbox = client.inboxSnapshot(INBOX_ID);
+  expect(inbox.length).toBe(2);
+});
+
+test('outbound send → operator reply: both turns in the same session, threaded', async () => {
+  const { channelId, emailAddress } = await seedEmailChannel();
+  const client = createFakeMailtrapClient({ sendInboxId: INBOX_ID });
+  const channel = buildHarness(client);
+
+  // 1. Agent initiates: outbound to the contact.
+  const sent = await channel.sendOutbound({
+    channelId,
+    toEmail: 'operator@example.com',
+    content: 'Are you available for a quick call?',
+    subject: 'Quick question',
+  });
+
+  // 2. Operator replies (via their email client → routed back to our inbox).
+  client.injectInbound(INBOX_ID, {
+    from: 'operator@example.com',
+    to: emailAddress,
+    subject: 'Re: Quick question',
+    text: 'Yes I am',
+    messageId: '<operator-reply-1@example.com>',
+    inReplyTo: sent.messageId,
+    references: [sent.messageId],
+  });
+
+  // 3. Poll to ingest the reply.
+  await channel.pollChannel(channelId);
+
+  // The reply must thread into the SAME session that the outbound created.
+  const db = getDb(pg.url);
+  const messages = await db.execute<{
+    sequence: number;
+    role: string;
+    content: string;
+    external_id: string | null;
+    session_id: string;
+  }>(
+    sql`SELECT sequence, role, content, external_id, session_id::text AS session_id FROM agent_message ORDER BY sequence`,
+  );
+  const sessionIds = new Set(messages.map((m) => m.session_id));
+  expect(sessionIds.size).toBe(1);
+  expect(sessionIds.has(sent.sessionId)).toBe(true);
+
+  // Sequence: assistant outbound → user inbound → assistant follow-up.
+  expect(messages.map((m) => m.role)).toEqual(['assistant', 'user', 'assistant']);
+  expect(messages[0]!.external_id).toBe(sent.messageId);
+  expect(messages[1]!.external_id).toBe('<operator-reply-1@example.com>');
+
+  // The follow-up reply on the wire threads to the operator's reply.
+  const latestSent = client
+    .inboxSnapshot(INBOX_ID)
+    .filter((m) => m.from === emailAddress)
+    .pop();
+  expect(latestSent!.inReplyTo).toBe('<operator-reply-1@example.com>');
+  expect(latestSent!.references).toContain(sent.messageId);
+  expect(latestSent!.references).toContain('<operator-reply-1@example.com>');
+});

--- a/apps/server/src/mail/email-channel.ts
+++ b/apps/server/src/mail/email-channel.ts
@@ -1,0 +1,152 @@
+// Email channel: polls Mailtrap inboxes for new mail, hands each new message
+// to the headless runtime as inbound, and sends the assistant's reply back
+// out through SMTP. Threading (RFC 5322 In-Reply-To / References) connects
+// inbound and outbound messages so an operator's reply lands in the same
+// agent_session as our outbound (PRD invariant #10).
+//
+// Outbound initiation reuses runtime.resolveSession to honor invariant #10:
+// the same code path that handles inbound creates/looks up the session for
+// outbound-first conversations.
+
+import { and, eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import {
+  agentMessage,
+  agentSession,
+  channel as channelTable,
+  channelInboundSeen,
+} from '../db/schema.ts';
+import type { MailtrapClient } from './client.ts';
+import { createSessionStore } from '../headless/session-store.ts';
+import type { createHeadlessRuntime } from '../headless/runtime.ts';
+
+export type EmailChannelDeps = {
+  db: PostgresJsDatabase;
+  client: MailtrapClient;
+  runtime: ReturnType<typeof createHeadlessRuntime>;
+};
+
+export function createEmailChannel({ db, client, runtime }: EmailChannelDeps) {
+  const store = createSessionStore({ db });
+
+  // Run one poll cycle for one channel: fetch the inbox, dispatch any unseen
+  // message through the runtime, and send the reply back through SMTP.
+  async function pollChannel(channelId: string): Promise<void> {
+    const [ch] = await db
+      .select()
+      .from(channelTable)
+      .where(eq(channelTable.id, channelId))
+      .limit(1);
+    if (!ch || ch.kind !== 'email' || !ch.mailtrapInboxId || !ch.emailAddress) return;
+
+    const messages = await client.listMessages(ch.mailtrapInboxId);
+    for (const msg of messages) {
+      // Skip our own outbound: the inbox holds both directions in the sandbox.
+      if (msg.from === ch.emailAddress) continue;
+
+      const inserted = await db
+        .insert(channelInboundSeen)
+        .values({ channelId: ch.id, externalId: msg.messageId })
+        .onConflictDoNothing()
+        .returning({ id: channelInboundSeen.id });
+      if (inserted.length === 0) continue; // already processed
+
+      // Reuse the same session resolver as the widget channel.
+      const resolved = await runtime.resolveSession({
+        channelId: ch.id,
+        identifierKind: 'email',
+        identifierValue: msg.from,
+        content: msg.text,
+      });
+
+      // Persist the user turn carrying the inbound Message-ID so a later
+      // reply (operator → us) can thread back into this session.
+      await store.append(resolved.sessionId, {
+        role: 'user',
+        content: msg.text,
+        externalId: msg.messageId,
+      });
+
+      // Invoke the agent over the session's full history (we just appended
+      // the inbound user turn).
+      const reply = await runtime.invokeOverHistory(resolved);
+
+      // Outbound: same `to` as the inbound's `from`, threaded via headers.
+      const outboundMessageId = generateMessageId(ch.emailAddress);
+      const references = [...(msg.references ?? []), msg.messageId];
+      await client.sendMail({
+        from: ch.emailAddress,
+        to: msg.from,
+        subject: replySubject(msg.subject),
+        text: reply,
+        messageId: outboundMessageId,
+        inReplyTo: msg.messageId,
+        references,
+      });
+
+      await store.append(resolved.sessionId, {
+        role: 'assistant',
+        content: reply,
+        externalId: outboundMessageId,
+      });
+    }
+  }
+
+  // Outbound-first send. The agent (or an operator on its behalf) initiates a
+  // conversation by emailing a contact. Reuses runtime.resolveSession so the
+  // session is the same one any subsequent inbound reply will land in.
+  async function sendOutbound(args: {
+    channelId: string;
+    toEmail: string;
+    content: string;
+    subject?: string;
+  }): Promise<{ sessionId: string; messageId: string }> {
+    const [ch] = await db
+      .select()
+      .from(channelTable)
+      .where(eq(channelTable.id, args.channelId))
+      .limit(1);
+    if (!ch || ch.kind !== 'email' || !ch.emailAddress) {
+      throw new Error(`channel not an email channel: ${args.channelId}`);
+    }
+
+    const resolved = await runtime.resolveSession({
+      channelId: ch.id,
+      identifierKind: 'email',
+      identifierValue: args.toEmail,
+      content: args.content,
+    });
+
+    const messageId = generateMessageId(ch.emailAddress);
+    await client.sendMail({
+      from: ch.emailAddress,
+      to: args.toEmail,
+      subject: args.subject ?? 'Hello',
+      text: args.content,
+      messageId,
+    });
+
+    await store.append(resolved.sessionId, {
+      role: 'assistant',
+      content: args.content,
+      externalId: messageId,
+    });
+    return { sessionId: resolved.sessionId, messageId };
+  }
+
+  return { pollChannel, sendOutbound };
+}
+
+// Re-export for callers that need to know the threaded subject convention.
+export function replySubject(original: string): string {
+  if (/^re:/i.test(original)) return original;
+  return `Re: ${original}`;
+}
+
+// RFC 5322 Message-ID with the channel's email domain so it looks plausible
+// in a real client. The local part is randomized so two outbound sends never
+// collide.
+export function generateMessageId(fromAddress: string): string {
+  const domain = fromAddress.split('@')[1] ?? 'nexus.local';
+  return `<${crypto.randomUUID()}@${domain}>`;
+}

--- a/apps/server/src/mail/email-channel.ts
+++ b/apps/server/src/mail/email-channel.ts
@@ -8,14 +8,9 @@
 // the same code path that handles inbound creates/looks up the session for
 // outbound-first conversations.
 
-import { and, eq } from 'drizzle-orm';
+import { eq } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import {
-  agentMessage,
-  agentSession,
-  channel as channelTable,
-  channelInboundSeen,
-} from '../db/schema.ts';
+import { channel as channelTable, channelInboundSeen } from '../db/schema.ts';
 import type { MailtrapClient } from './client.ts';
 import { createSessionStore } from '../headless/session-store.ts';
 import type { createHeadlessRuntime } from '../headless/runtime.ts';
@@ -137,8 +132,7 @@ export function createEmailChannel({ db, client, runtime }: EmailChannelDeps) {
   return { pollChannel, sendOutbound };
 }
 
-// Re-export for callers that need to know the threaded subject convention.
-export function replySubject(original: string): string {
+function replySubject(original: string): string {
   if (/^re:/i.test(original)) return original;
   return `Re: ${original}`;
 }
@@ -146,7 +140,7 @@ export function replySubject(original: string): string {
 // RFC 5322 Message-ID with the channel's email domain so it looks plausible
 // in a real client. The local part is randomized so two outbound sends never
 // collide.
-export function generateMessageId(fromAddress: string): string {
+function generateMessageId(fromAddress: string): string {
   const domain = fromAddress.split('@')[1] ?? 'nexus.local';
   return `<${crypto.randomUUID()}@${domain}>`;
 }

--- a/apps/server/src/mail/fake-client.ts
+++ b/apps/server/src/mail/fake-client.ts
@@ -1,0 +1,60 @@
+// In-memory MailtrapClient for tests. Mirrors the real client's contract:
+//   - sendMail drops the message into the configured "send inbox".
+//   - listMessages returns all messages in the named inbox.
+//
+// `injectInbound` lets a test simulate a customer (or an operator replying to
+// an agent's email) sending mail into an inbox. This stands in for the real
+// flow where mail arrives at a Mailtrap sandbox inbox from outside our system.
+//
+// Real Mailtrap sandbox: every email sent through the SMTP credentials lands
+// in the inbox those credentials authenticate, regardless of `to`. The fake
+// mirrors that — `sendMail` always appends to `sendInboxId`.
+
+import type { MailtrapClient, MailtrapInboundMessage, SendMailArgs } from './client.ts';
+
+export type FakeMailtrapClient = MailtrapClient & {
+  injectInbound(inboxId: string, msg: Omit<MailtrapInboundMessage, 'id'>): MailtrapInboundMessage;
+  inboxSnapshot(inboxId: string): MailtrapInboundMessage[];
+};
+
+export function createFakeMailtrapClient(opts: { sendInboxId: string }): FakeMailtrapClient {
+  const inboxes = new Map<string, MailtrapInboundMessage[]>();
+  let counter = 0;
+
+  function append(inboxId: string, msg: MailtrapInboundMessage): void {
+    const list = inboxes.get(inboxId);
+    if (list) list.push(msg);
+    else inboxes.set(inboxId, [msg]);
+  }
+
+  return {
+    async listMessages(inboxId) {
+      return [...(inboxes.get(inboxId) ?? [])];
+    },
+
+    async sendMail(args: SendMailArgs) {
+      counter += 1;
+      append(opts.sendInboxId, {
+        id: `sent-${counter}`,
+        from: args.from,
+        to: args.to,
+        subject: args.subject,
+        text: args.text,
+        messageId: args.messageId,
+        inReplyTo: args.inReplyTo,
+        references: args.references,
+      });
+    },
+
+    injectInbound(inboxId, msg) {
+      counter += 1;
+      const stored: MailtrapInboundMessage = { id: `inj-${counter}`, ...msg };
+      append(inboxId, stored);
+      return stored;
+    },
+
+    inboxSnapshot(inboxId) {
+      return [...(inboxes.get(inboxId) ?? [])];
+    },
+  };
+}

--- a/apps/server/src/routes/email.test.ts
+++ b/apps/server/src/routes/email.test.ts
@@ -1,0 +1,147 @@
+// POST /api/email/channels: operator connects an email channel + persists the
+// org's Mailtrap creds via the credential service.
+
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { agent, channel, org, session, user } from '../db/schema.ts';
+import { createCredentialService } from '../credentials/service.ts';
+import { emailRoute } from './email.ts';
+
+const TEST_KEY = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=';
+
+let pg: StartedPg;
+let app: Hono;
+let cookie: string;
+let agentId: string;
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(
+    sql`TRUNCATE TABLE "channel_inbound_seen", "agent_message", "agent_session", "identifier", "contact", "channel", "agent", "credential", "session", "user", "org" RESTART IDENTITY CASCADE`,
+  );
+
+  // Seed an org+user+session so resolveOrgId returns a real org.
+  const [o] = await db.insert(org).values({ name: 'op' }).returning();
+  const [u] = await db
+    .insert(user)
+    .values({ orgId: o!.id, email: 'op@example.com', passwordHash: 'x' })
+    .returning();
+  const token = crypto.randomUUID();
+  const tokenHash = new Bun.CryptoHasher('sha256').update(token).digest('hex');
+  await db.insert(session).values({
+    userId: u!.id,
+    tokenHash,
+    expiresAt: new Date(Date.now() + 60_000),
+  });
+  cookie = `nexus_session=${token}`;
+
+  const [a] = await db
+    .insert(agent)
+    .values({ orgId: o!.id, name: 'a', persona: 'p', model: 'm' })
+    .returning();
+  agentId = a!.id;
+
+  const credentials = createCredentialService({ db, encryptionKey: TEST_KEY });
+  app = new Hono();
+  app.route('/api/email', emailRoute({ db, credentials }));
+});
+
+test('POST /api/email/channels: creates channel and stores all four mailtrap creds', async () => {
+  const res = await app.request('/api/email/channels', {
+    method: 'POST',
+    headers: {
+      'content-type': 'application/json',
+      cookie,
+    },
+    body: JSON.stringify({
+      agentId,
+      emailAddress: 'agent@nexus.test',
+      mailtrapInboxId: 'inbox-1',
+      mailtrapAccountId: 'acc-1',
+      mailtrapApiToken: 'token-1',
+      mailtrapSmtpUser: 'smtp-user',
+      mailtrapSmtpPass: 'smtp-pass',
+    }),
+  });
+  expect(res.status).toBe(201);
+
+  const db = getDb(pg.url);
+  const channels = await db.select().from(channel);
+  expect(channels.length).toBe(1);
+  expect(channels[0]!.kind).toBe('email');
+  expect(channels[0]!.emailAddress).toBe('agent@nexus.test');
+  expect(channels[0]!.mailtrapInboxId).toBe('inbox-1');
+
+  const credentials = createCredentialService({
+    db,
+    encryptionKey: TEST_KEY,
+  });
+  expect(await credentials.get(channels[0]!.orgId, 'mailtrap', 'account_id')).toBe('acc-1');
+  expect(await credentials.get(channels[0]!.orgId, 'mailtrap', 'api_token')).toBe('token-1');
+  expect(await credentials.get(channels[0]!.orgId, 'mailtrap', 'smtp_user')).toBe('smtp-user');
+  expect(await credentials.get(channels[0]!.orgId, 'mailtrap', 'smtp_pass')).toBe('smtp-pass');
+});
+
+test('POST /api/email/channels: 401 without session cookie', async () => {
+  const res = await app.request('/api/email/channels', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      agentId,
+      emailAddress: 'agent@nexus.test',
+      mailtrapInboxId: 'i',
+      mailtrapAccountId: 'a',
+      mailtrapApiToken: 't',
+      mailtrapSmtpUser: 'u',
+      mailtrapSmtpPass: 'p',
+    }),
+  });
+  expect(res.status).toBe(401);
+});
+
+test('POST /api/email/channels: 404 if agent belongs to another org', async () => {
+  const db = getDb(pg.url);
+  // Make an agent in a different org.
+  const [other] = await db.insert(org).values({ name: 'other' }).returning();
+  const [otherAgent] = await db
+    .insert(agent)
+    .values({ orgId: other!.id, name: 'x', persona: 'y', model: 'z' })
+    .returning();
+
+  const res = await app.request('/api/email/channels', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({
+      agentId: otherAgent!.id,
+      emailAddress: 'agent@nexus.test',
+      mailtrapInboxId: 'i',
+      mailtrapAccountId: 'a',
+      mailtrapApiToken: 't',
+      mailtrapSmtpUser: 'u',
+      mailtrapSmtpPass: 'p',
+    }),
+  });
+  expect(res.status).toBe(404);
+});
+
+test('POST /api/email/channels: 400 for malformed payload', async () => {
+  const res = await app.request('/api/email/channels', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({ agentId, emailAddress: 'not-an-email' }),
+  });
+  expect(res.status).toBe(400);
+});

--- a/apps/server/src/routes/email.ts
+++ b/apps/server/src/routes/email.ts
@@ -1,0 +1,93 @@
+// Operator-facing email-channel routes.
+//
+//   POST /api/email/channels
+//     Connect an email channel for an agent. Stores the org's Mailtrap
+//     credentials via the credential service (#4) and creates the channel row
+//     with the inbox id + reply-from address.
+//
+// Mailtrap creds are scoped per-org: connecting a second email channel for
+// the same org overwrites the credentials (intentional — most orgs use one
+// Mailtrap project). Each channel has its own inbox id, kept on the channel
+// row.
+
+import { Hono } from 'hono';
+import * as v from 'valibot';
+import { and, eq } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { agent, channel } from '../db/schema.ts';
+import { resolveOrgId } from './_session-cookie.ts';
+import type { CredentialService } from '../credentials/service.ts';
+
+const ConnectInput = v.object({
+  agentId: v.pipe(v.string(), v.uuid()),
+  // The address the agent sends from. Real use: matches the verified domain
+  // on the operator's Mailtrap account.
+  emailAddress: v.pipe(v.string(), v.email()),
+  mailtrapInboxId: v.pipe(v.string(), v.minLength(1), v.maxLength(120)),
+  mailtrapAccountId: v.pipe(v.string(), v.minLength(1), v.maxLength(120)),
+  mailtrapApiToken: v.pipe(v.string(), v.minLength(1), v.maxLength(500)),
+  mailtrapSmtpUser: v.pipe(v.string(), v.minLength(1), v.maxLength(120)),
+  mailtrapSmtpPass: v.pipe(v.string(), v.minLength(1), v.maxLength(500)),
+});
+
+type Deps = { db: PostgresJsDatabase; credentials: CredentialService };
+
+export function emailRoute({ db, credentials }: Deps) {
+  const router = new Hono();
+
+  router.post('/channels', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+
+    const json = await safeJson(c.req.raw);
+    const parsed = v.safeParse(ConnectInput, json);
+    if (!parsed.success) return c.json({ error: 'invalid_email_channel_shape' }, 400);
+    const input = parsed.output;
+
+    // Confirm the agent belongs to this org before binding a channel to it.
+    const [a] = await db
+      .select({ id: agent.id })
+      .from(agent)
+      .where(and(eq(agent.id, input.agentId), eq(agent.orgId, orgId)))
+      .limit(1);
+    if (!a) return c.json({ error: 'agent_not_found' }, 404);
+
+    await credentials.set(orgId, 'mailtrap', 'account_id', input.mailtrapAccountId);
+    await credentials.set(orgId, 'mailtrap', 'api_token', input.mailtrapApiToken);
+    await credentials.set(orgId, 'mailtrap', 'smtp_user', input.mailtrapSmtpUser);
+    await credentials.set(orgId, 'mailtrap', 'smtp_pass', input.mailtrapSmtpPass);
+
+    const [created] = await db
+      .insert(channel)
+      .values({
+        orgId,
+        kind: 'email',
+        agentId: input.agentId,
+        emailAddress: input.emailAddress,
+        mailtrapInboxId: input.mailtrapInboxId,
+      })
+      .returning();
+    return c.json(
+      {
+        channel: {
+          id: created!.id,
+          kind: created!.kind,
+          agentId: created!.agentId,
+          emailAddress: created!.emailAddress,
+          mailtrapInboxId: created!.mailtrapInboxId,
+        },
+      },
+      201,
+    );
+  });
+
+  return router;
+}
+
+async function safeJson(req: Request): Promise<unknown> {
+  try {
+    return await req.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/server/src/test-helpers/e2e-server.ts
+++ b/apps/server/src/test-helpers/e2e-server.ts
@@ -16,7 +16,9 @@ import { authRoute } from '../routes/auth.ts';
 import { agentsRoute } from '../routes/agents.ts';
 import { widgetRoute } from '../routes/widget.ts';
 import { conversationsRoute } from '../routes/conversations.ts';
+import { emailRoute } from '../routes/email.ts';
 import { mountStatic } from '../routes/static.ts';
+import { createCredentialService } from '../credentials/service.ts';
 
 const port = Number.parseInt(process.env.E2E_PORT ?? '4173', 10);
 
@@ -29,9 +31,16 @@ const sessionRoot = await mkdtemp(join(tmpdir(), 'nexus-e2e-sessions-'));
 const app = new Hono();
 const db = getDb(pg.url);
 
+// 32-byte key, base64-encoded — only used by the e2e suite.
+const credentials = createCredentialService({
+  db,
+  encryptionKey: 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=',
+});
+
 app.route('/api/auth', authRoute({ db }));
 app.route('/api/agents', agentsRoute({ db }));
 app.route('/api/conversations', conversationsRoute({ db }));
+app.route('/api/email', emailRoute({ db, credentials }));
 app.route(
   '/widget',
   widgetRoute({

--- a/apps/web/src/pages/Agents.tsx
+++ b/apps/web/src/pages/Agents.tsx
@@ -1,4 +1,5 @@
 import { useCallback, useEffect, useState, type FormEvent } from 'react';
+import { ConnectEmailDialog } from './ConnectEmailDialog';
 
 export type Agent = {
   id: string;
@@ -35,6 +36,7 @@ export function Agents() {
   const [draft, setDraft] = useState<FormDraft>(EMPTY_DRAFT);
   const [submitting, setSubmitting] = useState(false);
   const [pendingDelete, setPendingDelete] = useState<DeleteTarget | null>(null);
+  const [connectEmailFor, setConnectEmailFor] = useState<Agent | null>(null);
 
   const refresh = useCallback(async () => {
     setLoading(true);
@@ -211,7 +213,19 @@ export function Agents() {
         agents={agents}
         onEdit={startEdit}
         onDelete={(a) => setPendingDelete({ id: a.id, name: a.name })}
+        onConnectEmail={(a) => setConnectEmailFor(a)}
       />
+
+      {connectEmailFor && (
+        <ConnectEmailDialog
+          agent={connectEmailFor}
+          onClose={() => setConnectEmailFor(null)}
+          onConnected={() => {
+            setConnectEmailFor(null);
+            void refresh();
+          }}
+        />
+      )}
 
       {pendingDelete && (
         <div
@@ -254,11 +268,13 @@ function AgentList({
   agents,
   onEdit,
   onDelete,
+  onConnectEmail,
 }: {
   loading: boolean;
   agents: Agent[];
   onEdit: (a: Agent) => void;
   onDelete: (a: Agent) => void;
+  onConnectEmail: (a: Agent) => void;
 }) {
   if (loading) {
     return <p className="text-zinc-400 text-sm">Loading…</p>;
@@ -293,6 +309,14 @@ function AgentList({
             )}
           </div>
           <div className="flex gap-2">
+            <button
+              type="button"
+              onClick={() => onConnectEmail(a)}
+              data-testid={`connect-email-${a.id}`}
+              className="rounded-md border border-zinc-700 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+            >
+              Connect email
+            </button>
             <button
               type="button"
               onClick={() => onEdit(a)}

--- a/apps/web/src/pages/ConnectEmailDialog.tsx
+++ b/apps/web/src/pages/ConnectEmailDialog.tsx
@@ -1,0 +1,189 @@
+// Operator-facing connect-email dialog.
+//
+// Captures the org's Mailtrap credentials and the per-channel inbox + send
+// address, then POSTs /api/email/channels which stores creds via the
+// credential service (#4) and creates the channel row.
+//
+// Inline explanation up front: this is the first time most operators will
+// have seen Mailtrap referenced in the platform; the copy makes it clear what
+// the four fields are for and where to find them in their Mailtrap account.
+
+import { useState, type FormEvent } from 'react';
+import type { Agent } from './Agents';
+
+type Draft = {
+  emailAddress: string;
+  mailtrapInboxId: string;
+  mailtrapAccountId: string;
+  mailtrapApiToken: string;
+  mailtrapSmtpUser: string;
+  mailtrapSmtpPass: string;
+};
+
+const EMPTY: Draft = {
+  emailAddress: '',
+  mailtrapInboxId: '',
+  mailtrapAccountId: '',
+  mailtrapApiToken: '',
+  mailtrapSmtpUser: '',
+  mailtrapSmtpPass: '',
+};
+
+export function ConnectEmailDialog({
+  agent,
+  onClose,
+  onConnected,
+}: {
+  agent: Agent;
+  onClose: () => void;
+  onConnected: () => void;
+}) {
+  const [draft, setDraft] = useState<Draft>(EMPTY);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/email/channels', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ agentId: agent.id, ...draft }),
+      });
+      if (!res.ok) throw new Error(`Failed to connect (${res.status})`);
+      onConnected();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to connect.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  return (
+    <div
+      data-testid="connect-email-dialog"
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-10 flex items-center justify-center bg-black/60 p-4"
+    >
+      <form
+        onSubmit={onSubmit}
+        className="w-full max-w-lg space-y-4 rounded-lg border border-zinc-800 bg-zinc-900 p-5"
+      >
+        <header>
+          <h2 className="text-lg font-semibold">Connect email — {agent.name}</h2>
+          <p className="mt-1 text-sm text-zinc-400">
+            Wire up an email channel for this agent through Mailtrap. We use
+            Mailtrap's sandbox SMTP to send replies and its inbox API to pick
+            up incoming mail. You'll find the four credential fields below in
+            the <span className="text-zinc-200">Integration</span> tab of your
+            Mailtrap sandbox inbox.
+          </p>
+        </header>
+
+        {error && (
+          <p role="alert" className="text-sm text-red-400">
+            {error}
+          </p>
+        )}
+
+        <Field
+          label="Reply-from address"
+          hint="Address the agent's outbound emails will come from."
+          value={draft.emailAddress}
+          onChange={(emailAddress) => setDraft((d) => ({ ...d, emailAddress }))}
+          type="email"
+          testid="email-address"
+        />
+        <Field
+          label="Mailtrap inbox ID"
+          hint="From the URL of your sandbox inbox: .../inboxes/{inbox_id}."
+          value={draft.mailtrapInboxId}
+          onChange={(mailtrapInboxId) => setDraft((d) => ({ ...d, mailtrapInboxId }))}
+          testid="mailtrap-inbox-id"
+        />
+        <Field
+          label="Mailtrap account ID"
+          hint="From the same URL: .../accounts/{account_id}/..."
+          value={draft.mailtrapAccountId}
+          onChange={(mailtrapAccountId) => setDraft((d) => ({ ...d, mailtrapAccountId }))}
+          testid="mailtrap-account-id"
+        />
+        <Field
+          label="Mailtrap API token"
+          hint="Found under My Profile → API Tokens."
+          value={draft.mailtrapApiToken}
+          onChange={(mailtrapApiToken) => setDraft((d) => ({ ...d, mailtrapApiToken }))}
+          type="password"
+          testid="mailtrap-api-token"
+        />
+        <Field
+          label="SMTP username"
+          hint="Shown under the Integration tab of your sandbox inbox."
+          value={draft.mailtrapSmtpUser}
+          onChange={(mailtrapSmtpUser) => setDraft((d) => ({ ...d, mailtrapSmtpUser }))}
+          testid="mailtrap-smtp-user"
+        />
+        <Field
+          label="SMTP password"
+          hint="Shown next to the SMTP username."
+          value={draft.mailtrapSmtpPass}
+          onChange={(mailtrapSmtpPass) => setDraft((d) => ({ ...d, mailtrapSmtpPass }))}
+          type="password"
+          testid="mailtrap-smtp-pass"
+        />
+
+        <div className="flex justify-end gap-2">
+          <button
+            type="button"
+            onClick={onClose}
+            className="rounded-md border border-zinc-700 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-800"
+          >
+            Cancel
+          </button>
+          <button
+            type="submit"
+            disabled={submitting}
+            className="rounded-md bg-emerald-500 px-3 py-1.5 text-sm font-medium text-zinc-950 hover:bg-emerald-400 disabled:opacity-60"
+          >
+            {submitting ? 'Connecting…' : 'Connect'}
+          </button>
+        </div>
+      </form>
+    </div>
+  );
+}
+
+function Field({
+  label,
+  value,
+  onChange,
+  hint,
+  type,
+  testid,
+}: {
+  label: string;
+  value: string;
+  onChange: (next: string) => void;
+  hint?: string;
+  type?: string;
+  testid?: string;
+}) {
+  return (
+    <label className="block text-sm">
+      <span className="block text-zinc-300 mb-1">{label}</span>
+      <input
+        type={type ?? 'text'}
+        value={value}
+        required
+        data-testid={testid}
+        onChange={(e) => onChange(e.target.value)}
+        className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-zinc-100 outline-none focus:border-emerald-500"
+      />
+      {hint && <span className="mt-1 block text-xs text-zinc-500">{hint}</span>}
+    </label>
+  );
+}

--- a/bun.lock
+++ b/bun.lock
@@ -17,12 +17,18 @@
         "@nexus/logger": "workspace:*",
         "drizzle-orm": "^0.36.4",
         "hono": "^4.6.12",
+        "mailparser": "^3.9.8",
         "minio": "^8.0.2",
+        "nodemailer": "^8.0.7",
         "postgres": "^3.4.5",
+        "smtp-server": "^3.18.4",
         "valibot": "^1.0.0-beta.9",
       },
       "devDependencies": {
         "@types/bun": "^1.1.17",
+        "@types/mailparser": "^3.4.6",
+        "@types/nodemailer": "^8.0.0",
+        "@types/smtp-server": "^3.5.13",
         "drizzle-kit": "^0.28.1",
         "typescript": "^5.6.3",
       },
@@ -227,6 +233,8 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
 
+    "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
+
     "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.4", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.4", "@tailwindcss/oxide-darwin-arm64": "4.2.4", "@tailwindcss/oxide-darwin-x64": "4.2.4", "@tailwindcss/oxide-freebsd-x64": "4.2.4", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4", "@tailwindcss/oxide-linux-arm64-musl": "4.2.4", "@tailwindcss/oxide-linux-x64-gnu": "4.2.4", "@tailwindcss/oxide-linux-x64-musl": "4.2.4", "@tailwindcss/oxide-wasm32-wasi": "4.2.4", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4", "@tailwindcss/oxide-win32-x64-msvc": "4.2.4" } }, "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q=="],
@@ -269,13 +277,21 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
+    "@types/mailparser": ["@types/mailparser@3.4.6", "", { "dependencies": { "@types/node": "*", "iconv-lite": "^0.6.3" } }, "sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q=="],
+
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
+
+    "@types/nodemailer": ["@types/nodemailer@8.0.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA=="],
 
     "@types/react": ["@types/react@19.2.14", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w=="],
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
+    "@types/smtp-server": ["@types/smtp-server@3.5.13", "", { "dependencies": { "@types/node": "*", "@types/nodemailer": "*" } }, "sha512-S3rGl2KbViH+98/CgHipPIWgtAFnjxLsppxIRbgJHNuZL7Y+py+7kZjT7xS+wOmCxYTn4O7IqLqkvekg99MDVQ=="],
+
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
+
+    "@zone-eu/mailsplit": ["@zone-eu/mailsplit@5.4.8", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.3.7", "libqp": "2.1.1" } }, "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
@@ -305,7 +321,17 @@
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "drizzle-kit": ["drizzle-kit@0.28.1", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-JimOV+ystXTWMgZkLHYHf2w3oS28hxiH1FR0dkmJLc7GHzdGJoJAQtQS5DRppnabsRZwE2U1F6CuezVBgmsBBQ=="],
 
@@ -313,7 +339,11 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
 
+    "encoding-japanese": ["encoding-japanese@2.2.0", "", {}, "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A=="],
+
     "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
+
+    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
@@ -339,11 +369,21 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
+    "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
+
     "hono": ["hono@4.12.15", "", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
+
+    "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
+
+    "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
+
+    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
+
+    "ipv6-normalize": ["ipv6-normalize@1.0.1", "", {}, "sha512-Bm6H79i01DjgGTCWjUuCjJ6QDo1HB96PT/xCYuyJUP9WFbVDrLSbG4EZCvOCun2rNswZb0c3e4Jt/ws795esHA=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -352,6 +392,14 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
+
+    "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
+
+    "libbase64": ["libbase64@1.3.0", "", {}, "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg=="],
+
+    "libmime": ["libmime@5.3.8", "", { "dependencies": { "encoding-japanese": "2.2.0", "iconv-lite": "0.7.2", "libbase64": "1.3.0", "libqp": "2.1.1" } }, "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng=="],
+
+    "libqp": ["libqp@2.1.1", "", {}, "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -377,11 +425,15 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
+    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
+
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "mailparser": ["mailparser@3.9.8", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.8", "encoding-japanese": "2.2.0", "he": "1.2.0", "html-to-text": "9.0.5", "iconv-lite": "0.7.2", "libmime": "5.3.8", "linkify-it": "5.0.0", "nodemailer": "8.0.5", "punycode.js": "2.3.1", "tlds": "1.261.0" } }, "sha512-7jSlFGXiianVnhnb6wdutJFloD34488nrHY7r6FNqwXAhZ7YiJDYrKKTxZJ0oSrXcAPHm8YoYnh97xyGtrBQ3w=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -395,7 +447,13 @@
 
     "node-releases": ["node-releases@2.0.38", "", {}, "sha512-3qT/88Y3FbH/Kx4szpQQ4HzUbVrHPKTLVpVocKiLfoYvw9XSGOX2FmD2d6DrXbVYyAQTF2HeF6My8jmzx7/CRw=="],
 
+    "nodemailer": ["nodemailer@8.0.7", "", {}, "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow=="],
+
+    "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
+
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
+
+    "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -408,6 +466,8 @@
     "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
+
+    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "query-string": ["query-string@7.1.3", "", { "dependencies": { "decode-uri-component": "^0.2.2", "filter-obj": "^1.1.0", "split-on-first": "^1.0.0", "strict-uri-encode": "^2.0.0" } }, "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg=="],
 
@@ -429,13 +489,19 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
+    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
+    "selderee": ["selderee@0.11.0", "", { "dependencies": { "parseley": "^0.12.0" } }, "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA=="],
+
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
+
+    "smtp-server": ["smtp-server@3.18.4", "", { "dependencies": { "ipv6-normalize": "1.0.1", "nodemailer": "8.0.5", "punycode.js": "2.3.1" } }, "sha512-9EnXPG4Tv+2P/TSEUdFTduYn9IxtxNRsOq/ryVj8ZlT+6MU2um9gn2Td2hHlgH1n+saagMWtici3hn5J5PhU+g=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -463,7 +529,11 @@
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
+    "tlds": ["tlds@1.261.0", "", { "bin": { "tlds": "bin.js" } }, "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA=="],
+
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -497,7 +567,17 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
+    "@zone-eu/mailsplit/libmime": ["libmime@5.3.7", "", { "dependencies": { "encoding-japanese": "2.2.0", "iconv-lite": "0.6.3", "libbase64": "1.3.0", "libqp": "2.1.1" } }, "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw=="],
+
+    "libmime/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "mailparser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
+
+    "mailparser/nodemailer": ["nodemailer@8.0.5", "", {}, "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="],
+
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
+
+    "smtp-server/nodemailer": ["nodemailer@8.0.5", "", {}, "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="],
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,18 +17,14 @@
         "@nexus/logger": "workspace:*",
         "drizzle-orm": "^0.36.4",
         "hono": "^4.6.12",
-        "mailparser": "^3.9.8",
         "minio": "^8.0.2",
         "nodemailer": "^8.0.7",
         "postgres": "^3.4.5",
-        "smtp-server": "^3.18.4",
         "valibot": "^1.0.0-beta.9",
       },
       "devDependencies": {
         "@types/bun": "^1.1.17",
-        "@types/mailparser": "^3.4.6",
         "@types/nodemailer": "^8.0.0",
-        "@types/smtp-server": "^3.5.13",
         "drizzle-kit": "^0.28.1",
         "typescript": "^5.6.3",
       },
@@ -233,8 +229,6 @@
 
     "@rollup/rollup-win32-x64-msvc": ["@rollup/rollup-win32-x64-msvc@4.60.2", "", { "os": "win32", "cpu": "x64" }, "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA=="],
 
-    "@selderee/plugin-htmlparser2": ["@selderee/plugin-htmlparser2@0.11.0", "", { "dependencies": { "domhandler": "^5.0.3", "selderee": "^0.11.0" } }, "sha512-P33hHGdldxGabLFjPPpaTxVolMrzrcegejx+0GxjrIb9Zv48D8yAIA/QTDR2dFl7Uz7urX8aX6+5bCZslr+gWQ=="],
-
     "@tailwindcss/node": ["@tailwindcss/node@4.2.4", "", { "dependencies": { "@jridgewell/remapping": "^2.3.5", "enhanced-resolve": "^5.19.0", "jiti": "^2.6.1", "lightningcss": "1.32.0", "magic-string": "^0.30.21", "source-map-js": "^1.2.1", "tailwindcss": "4.2.4" } }, "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA=="],
 
     "@tailwindcss/oxide": ["@tailwindcss/oxide@4.2.4", "", { "optionalDependencies": { "@tailwindcss/oxide-android-arm64": "4.2.4", "@tailwindcss/oxide-darwin-arm64": "4.2.4", "@tailwindcss/oxide-darwin-x64": "4.2.4", "@tailwindcss/oxide-freebsd-x64": "4.2.4", "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4", "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4", "@tailwindcss/oxide-linux-arm64-musl": "4.2.4", "@tailwindcss/oxide-linux-x64-gnu": "4.2.4", "@tailwindcss/oxide-linux-x64-musl": "4.2.4", "@tailwindcss/oxide-wasm32-wasi": "4.2.4", "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4", "@tailwindcss/oxide-win32-x64-msvc": "4.2.4" } }, "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q=="],
@@ -277,8 +271,6 @@
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
-    "@types/mailparser": ["@types/mailparser@3.4.6", "", { "dependencies": { "@types/node": "*", "iconv-lite": "^0.6.3" } }, "sha512-wVV3cnIKzxTffaPH8iRnddX1zahbYB1ZEoAxyhoBo3TBCBuK6nZ8M8JYO/RhsCuuBVOw/DEN/t/ENbruwlxn6Q=="],
-
     "@types/node": ["@types/node@25.6.0", "", { "dependencies": { "undici-types": "~7.19.0" } }, "sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ=="],
 
     "@types/nodemailer": ["@types/nodemailer@8.0.0", "", { "dependencies": { "@types/node": "*" } }, "sha512-fyf8jWULsCo0d0BuoQ75i6IeoHs47qcqxWc7yUdUcV0pOZGjUTTOvwdG1PRXUDqN/8A64yQdQdnA2pZgcdi+cA=="],
@@ -287,11 +279,7 @@
 
     "@types/react-dom": ["@types/react-dom@19.2.3", "", { "peerDependencies": { "@types/react": "^19.2.0" } }, "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ=="],
 
-    "@types/smtp-server": ["@types/smtp-server@3.5.13", "", { "dependencies": { "@types/node": "*", "@types/nodemailer": "*" } }, "sha512-S3rGl2KbViH+98/CgHipPIWgtAFnjxLsppxIRbgJHNuZL7Y+py+7kZjT7xS+wOmCxYTn4O7IqLqkvekg99MDVQ=="],
-
     "@vitejs/plugin-react": ["@vitejs/plugin-react@4.7.0", "", { "dependencies": { "@babel/core": "^7.28.0", "@babel/plugin-transform-react-jsx-self": "^7.27.1", "@babel/plugin-transform-react-jsx-source": "^7.27.1", "@rolldown/pluginutils": "1.0.0-beta.27", "@types/babel__core": "^7.20.5", "react-refresh": "^0.17.0" }, "peerDependencies": { "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0" } }, "sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA=="],
-
-    "@zone-eu/mailsplit": ["@zone-eu/mailsplit@5.4.8", "", { "dependencies": { "libbase64": "1.3.0", "libmime": "5.3.7", "libqp": "2.1.1" } }, "sha512-eEyACj4JZ7sjzRvy26QhLgKEMWwQbsw1+QZnlLX+/gihcNH07lVPOcnwf5U6UAL7gkc//J3jVd76o/WS+taUiA=="],
 
     "async": ["async@3.2.6", "", {}, "sha512-htCUDlxyyCLMgaM3xXg0C0LW2xqfuQ6p05pCEIsXuyQ+a1koYKTuBMzRNwmybfLgvJDMd0r1LTn4+E0Ti6C2AA=="],
 
@@ -321,17 +309,7 @@
 
     "decode-uri-component": ["decode-uri-component@0.2.2", "", {}, "sha512-FqUYQ+8o158GyGTrMFJms9qh3CqTKvAqgqsTnkLI8sKu0028orqBhxNMFkFen0zGyg6epACD32pjVk58ngIErQ=="],
 
-    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
-
     "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
-
-    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
-
-    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
-
-    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
-
-    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
 
     "drizzle-kit": ["drizzle-kit@0.28.1", "", { "dependencies": { "@drizzle-team/brocli": "^0.10.2", "@esbuild-kit/esm-loader": "^2.5.5", "esbuild": "^0.19.7", "esbuild-register": "^3.5.0" }, "bin": { "drizzle-kit": "bin.cjs" } }, "sha512-JimOV+ystXTWMgZkLHYHf2w3oS28hxiH1FR0dkmJLc7GHzdGJoJAQtQS5DRppnabsRZwE2U1F6CuezVBgmsBBQ=="],
 
@@ -339,11 +317,7 @@
 
     "electron-to-chromium": ["electron-to-chromium@1.5.344", "", {}, "sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg=="],
 
-    "encoding-japanese": ["encoding-japanese@2.2.0", "", {}, "sha512-EuJWwlHPZ1LbADuKTClvHtwbaFn4rOD+dRAbWysqEOXRc2Uui0hJInNJrsdH0c+OhJA4nrCBdSkW4DD5YxAo6A=="],
-
     "enhanced-resolve": ["enhanced-resolve@5.21.0", "", { "dependencies": { "graceful-fs": "^4.2.4", "tapable": "^2.3.3" } }, "sha512-otxSQPw4lkOZWkHpB3zaEQs6gWYEsmX4xQF68ElXC/TWvGxGMSGOvoNbaLXm6/cS/fSfHtsEdw90y20PCd+sCA=="],
-
-    "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
 
     "esbuild": ["esbuild@0.19.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.19.12", "@esbuild/android-arm": "0.19.12", "@esbuild/android-arm64": "0.19.12", "@esbuild/android-x64": "0.19.12", "@esbuild/darwin-arm64": "0.19.12", "@esbuild/darwin-x64": "0.19.12", "@esbuild/freebsd-arm64": "0.19.12", "@esbuild/freebsd-x64": "0.19.12", "@esbuild/linux-arm": "0.19.12", "@esbuild/linux-arm64": "0.19.12", "@esbuild/linux-ia32": "0.19.12", "@esbuild/linux-loong64": "0.19.12", "@esbuild/linux-mips64el": "0.19.12", "@esbuild/linux-ppc64": "0.19.12", "@esbuild/linux-riscv64": "0.19.12", "@esbuild/linux-s390x": "0.19.12", "@esbuild/linux-x64": "0.19.12", "@esbuild/netbsd-x64": "0.19.12", "@esbuild/openbsd-x64": "0.19.12", "@esbuild/sunos-x64": "0.19.12", "@esbuild/win32-arm64": "0.19.12", "@esbuild/win32-ia32": "0.19.12", "@esbuild/win32-x64": "0.19.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-aARqgq8roFBj054KvQr5f1sFu0D65G+miZRCuJyJ0G13Zwx7vRar5Zhn2tkQNzIXcBrNVsv/8stehpj+GAjgbg=="],
 
@@ -369,21 +343,11 @@
 
     "graceful-fs": ["graceful-fs@4.2.11", "", {}, "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ=="],
 
-    "he": ["he@1.2.0", "", { "bin": { "he": "bin/he" } }, "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw=="],
-
     "hono": ["hono@4.12.15", "", {}, "sha512-qM0jDhFEaCBb4TxoW7f53Qrpv9RBiayUHo0S52JudprkhvpjIrGoU1mnnr29Fvd1U335ZFPZQY1wlkqgfGXyLg=="],
-
-    "html-to-text": ["html-to-text@9.0.5", "", { "dependencies": { "@selderee/plugin-htmlparser2": "^0.11.0", "deepmerge": "^4.3.1", "dom-serializer": "^2.0.0", "htmlparser2": "^8.0.2", "selderee": "^0.11.0" } }, "sha512-qY60FjREgVZL03vJU6IfMV4GDjGBIoOyvuFdpBDIX9yTlDw0TjxVBQp+P8NvpdIXNJvfWBTNul7fsAQJq2FNpg=="],
-
-    "htmlparser2": ["htmlparser2@8.0.2", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.0.1", "entities": "^4.4.0" } }, "sha512-GYdjWKDkbRLkZ5geuHs5NY1puJ+PXwP7+fHPRz06Eirsb9ugf6d8kkXav6ADhcODhFFPMIXyxkxSuMf3D6NCFA=="],
-
-    "iconv-lite": ["iconv-lite@0.6.3", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw=="],
 
     "inherits": ["inherits@2.0.4", "", {}, "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="],
 
     "ipaddr.js": ["ipaddr.js@2.3.0", "", {}, "sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg=="],
-
-    "ipv6-normalize": ["ipv6-normalize@1.0.1", "", {}, "sha512-Bm6H79i01DjgGTCWjUuCjJ6QDo1HB96PT/xCYuyJUP9WFbVDrLSbG4EZCvOCun2rNswZb0c3e4Jt/ws795esHA=="],
 
     "jiti": ["jiti@2.6.1", "", { "bin": { "jiti": "lib/jiti-cli.mjs" } }, "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ=="],
 
@@ -392,14 +356,6 @@
     "jsesc": ["jsesc@3.1.0", "", { "bin": { "jsesc": "bin/jsesc" } }, "sha512-/sM3dO2FOzXjKQhJuo0Q173wf2KOo8t4I8vHy6lF9poUp7bKT0/NHE8fPX23PwfhnykfqnC2xRxOnVw5XuGIaA=="],
 
     "json5": ["json5@2.2.3", "", { "bin": { "json5": "lib/cli.js" } }, "sha512-XmOWe7eyHYH14cLdVPoyg+GOH3rYX++KpzrylJwSW98t3Nk+U8XOl8FWKOgwtzdb8lXGf6zYwDUzeHMWfxasyg=="],
-
-    "leac": ["leac@0.6.0", "", {}, "sha512-y+SqErxb8h7nE/fiEX07jsbuhrpO9lL8eca7/Y1nuWV2moNlXhyd59iDGcRf6moVyDMbmTNzL40SUyrFU/yDpg=="],
-
-    "libbase64": ["libbase64@1.3.0", "", {}, "sha512-GgOXd0Eo6phYgh0DJtjQ2tO8dc0IVINtZJeARPeiIJqge+HdsWSuaDTe8ztQ7j/cONByDZ3zeB325AHiv5O0dg=="],
-
-    "libmime": ["libmime@5.3.8", "", { "dependencies": { "encoding-japanese": "2.2.0", "iconv-lite": "0.7.2", "libbase64": "1.3.0", "libqp": "2.1.1" } }, "sha512-ZrCY+Q66mPvasAfjsQ/IgahzoBvfE1VdtGRpo1hwRB1oK3wJKxhKA3GOcd2a6j7AH5eMFccxK9fBoCpRZTf8ng=="],
-
-    "libqp": ["libqp@2.1.1", "", {}, "sha512-0Wd+GPz1O134cP62YU2GTOPNA7Qgl09XwCqM5zpBv87ERCXdfDtyKXvV7c9U22yWJh44QZqBocFnXN11K96qow=="],
 
     "lightningcss": ["lightningcss@1.32.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.32.0", "lightningcss-darwin-arm64": "1.32.0", "lightningcss-darwin-x64": "1.32.0", "lightningcss-freebsd-x64": "1.32.0", "lightningcss-linux-arm-gnueabihf": "1.32.0", "lightningcss-linux-arm64-gnu": "1.32.0", "lightningcss-linux-arm64-musl": "1.32.0", "lightningcss-linux-x64-gnu": "1.32.0", "lightningcss-linux-x64-musl": "1.32.0", "lightningcss-win32-arm64-msvc": "1.32.0", "lightningcss-win32-x64-msvc": "1.32.0" } }, "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ=="],
 
@@ -425,15 +381,11 @@
 
     "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.32.0", "", { "os": "win32", "cpu": "x64" }, "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q=="],
 
-    "linkify-it": ["linkify-it@5.0.0", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ=="],
-
     "lodash": ["lodash@4.18.1", "", {}, "sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q=="],
 
     "lru-cache": ["lru-cache@5.1.1", "", { "dependencies": { "yallist": "^3.0.2" } }, "sha512-KpNARQA3Iwv+jTA0utUVVbrh+Jlrr1Fv0e56GGzAFOXN7dk/FviaDW8LHmK52DlcH4WP2n6gI8vN1aesBFgo9w=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
-
-    "mailparser": ["mailparser@3.9.8", "", { "dependencies": { "@zone-eu/mailsplit": "5.4.8", "encoding-japanese": "2.2.0", "he": "1.2.0", "html-to-text": "9.0.5", "iconv-lite": "0.7.2", "libmime": "5.3.8", "linkify-it": "5.0.0", "nodemailer": "8.0.5", "punycode.js": "2.3.1", "tlds": "1.261.0" } }, "sha512-7jSlFGXiianVnhnb6wdutJFloD34488nrHY7r6FNqwXAhZ7YiJDYrKKTxZJ0oSrXcAPHm8YoYnh97xyGtrBQ3w=="],
 
     "mime-db": ["mime-db@1.52.0", "", {}, "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg=="],
 
@@ -449,11 +401,7 @@
 
     "nodemailer": ["nodemailer@8.0.7", "", {}, "sha512-pkjE4mkBzQjdJT4/UmlKl3pX0rC9fZmjh7c6C9o7lv66Ac6w9WCnzPzhbPNxwZAzlF4mdq4CSWB5+FbK6FWCow=="],
 
-    "parseley": ["parseley@0.12.1", "", { "dependencies": { "leac": "^0.6.0", "peberminta": "^0.9.0" } }, "sha512-e6qHKe3a9HWr0oMRVDTRhKce+bRO8VGQR3NyVwcjwrbhMmFCX9KszEV35+rn4AdilFAq9VPxP/Fe1wC9Qjd2lw=="],
-
     "path-expression-matcher": ["path-expression-matcher@1.5.0", "", {}, "sha512-cbrerZV+6rvdQrrD+iGMcZFEiiSrbv9Tfdkvnusy6y0x0GKBXREFg/Y65GhIfm0tnLntThhzCnfKwp1WRjeCyQ=="],
-
-    "peberminta": ["peberminta@0.9.0", "", {}, "sha512-XIxfHpEuSJbITd1H3EeQwpcZbTLHc+VVr8ANI9t5sit565tsI4/xK3KWTUFE2e6QiangUkh3B0jihzmGnNrRsQ=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -466,8 +414,6 @@
     "postcss": ["postcss@8.5.12", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-W62t/Se6rA0Az3DfCL0AqJwXuKwBeYg6nOaIgzP+xZ7N5BFCI7DYi1qs6ygUYT6rvfi6t9k65UMLJC+PHZpDAA=="],
 
     "postgres": ["postgres@3.4.9", "", {}, "sha512-GD3qdB0x1z9xgFI6cdRD6xu2Sp2WCOEoe3mtnyB5Ee0XrrL5Pe+e4CCnJrRMnL1zYtRDZmQQVbvOttLnKDLnaw=="],
-
-    "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
     "query-string": ["query-string@7.1.3", "", { "dependencies": { "decode-uri-component": "^0.2.2", "filter-obj": "^1.1.0", "split-on-first": "^1.0.0", "strict-uri-encode": "^2.0.0" } }, "sha512-hh2WYhq4fi8+b+/2Kg9CEge4fDPvHS534aOOvOZeQ3+Vf2mCFsaFBYj0i+iXcAq6I9Vzp5fjMFBlONvayDC1qg=="],
 
@@ -489,19 +435,13 @@
 
     "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
 
-    "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
-
     "sax": ["sax@1.6.0", "", {}, "sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA=="],
 
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
-    "selderee": ["selderee@0.11.0", "", { "dependencies": { "parseley": "^0.12.0" } }, "sha512-5TF+l7p4+OsnP8BCCvSyZiSPc4x4//p5uPwK8TCnVPJYRmU2aYKMpOXvw8zM5a5JvuuCGN1jmsMwuU2W02ukfA=="],
-
     "semver": ["semver@6.3.1", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA=="],
 
     "set-cookie-parser": ["set-cookie-parser@2.7.2", "", {}, "sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw=="],
-
-    "smtp-server": ["smtp-server@3.18.4", "", { "dependencies": { "ipv6-normalize": "1.0.1", "nodemailer": "8.0.5", "punycode.js": "2.3.1" } }, "sha512-9EnXPG4Tv+2P/TSEUdFTduYn9IxtxNRsOq/ryVj8ZlT+6MU2um9gn2Td2hHlgH1n+saagMWtici3hn5J5PhU+g=="],
 
     "source-map": ["source-map@0.6.1", "", {}, "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="],
 
@@ -529,11 +469,7 @@
 
     "tinyglobby": ["tinyglobby@0.2.16", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg=="],
 
-    "tlds": ["tlds@1.261.0", "", { "bin": { "tlds": "bin.js" } }, "sha512-QXqwfEl9ddlGBaRFXIvNKK6OhipSiLXuRuLJX5DErz0o0Q0rYxulWLdFryTkV5PkdZct5iMInwYEGe/eR++1AA=="],
-
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
-
-    "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
     "undici-types": ["undici-types@7.19.2", "", {}, "sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg=="],
 
@@ -567,17 +503,7 @@
 
     "@tailwindcss/oxide-wasm32-wasi/tslib": ["tslib@2.8.1", "", { "bundled": true }, "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w=="],
 
-    "@zone-eu/mailsplit/libmime": ["libmime@5.3.7", "", { "dependencies": { "encoding-japanese": "2.2.0", "iconv-lite": "0.6.3", "libbase64": "1.3.0", "libqp": "2.1.1" } }, "sha512-FlDb3Wtha8P01kTL3P9M+ZDNDWPKPmKHWaU/cG/lg5pfuAwdflVpZE+wm9m7pKmC5ww6s+zTxBKS1p6yl3KpSw=="],
-
-    "libmime/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
-    "mailparser/iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
-
-    "mailparser/nodemailer": ["nodemailer@8.0.5", "", {}, "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="],
-
     "playwright/fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
-
-    "smtp-server/nodemailer": ["nodemailer@8.0.5", "", {}, "sha512-0PF8Yb1yZuQfQbq+5/pZJrtF6WQcjTd5/S4JOHs9PGFxuTqoB/icwuB44pOdURHJbRKX1PPoJZtY7R4VUoCC8w=="],
 
     "vite/esbuild": ["esbuild@0.25.12", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.12", "@esbuild/android-arm": "0.25.12", "@esbuild/android-arm64": "0.25.12", "@esbuild/android-x64": "0.25.12", "@esbuild/darwin-arm64": "0.25.12", "@esbuild/darwin-x64": "0.25.12", "@esbuild/freebsd-arm64": "0.25.12", "@esbuild/freebsd-x64": "0.25.12", "@esbuild/linux-arm": "0.25.12", "@esbuild/linux-arm64": "0.25.12", "@esbuild/linux-ia32": "0.25.12", "@esbuild/linux-loong64": "0.25.12", "@esbuild/linux-mips64el": "0.25.12", "@esbuild/linux-ppc64": "0.25.12", "@esbuild/linux-riscv64": "0.25.12", "@esbuild/linux-s390x": "0.25.12", "@esbuild/linux-x64": "0.25.12", "@esbuild/netbsd-arm64": "0.25.12", "@esbuild/netbsd-x64": "0.25.12", "@esbuild/openbsd-arm64": "0.25.12", "@esbuild/openbsd-x64": "0.25.12", "@esbuild/openharmony-arm64": "0.25.12", "@esbuild/sunos-x64": "0.25.12", "@esbuild/win32-arm64": "0.25.12", "@esbuild/win32-ia32": "0.25.12", "@esbuild/win32-x64": "0.25.12" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg=="],
 

--- a/tests/e2e/email.spec.ts
+++ b/tests/e2e/email.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from '@playwright/test';
+
+// Operator-facing connect-email-channel flow.
+//
+// Inbound polling and threading are exercised in the bun integration tests
+// (`apps/server/src/mail/email-channel.test.ts`) — those don't need a
+// browser. This Playwright test covers the UI path the operator drives:
+// open the dialog, see the inline explanation, fill the form, submit, and
+// observe a successful response.
+
+test('operator connects an email channel for an agent', async ({ page }) => {
+  const email = `op+email+${Date.now()}@example.com`;
+  const password = 'hunter2hunter2';
+
+  await page.goto('/register');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password (8+ characters)').fill(password);
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page.getByTestId('dashboard')).toBeVisible();
+
+  await page.getByRole('link', { name: 'Agents' }).click();
+  await page.getByRole('button', { name: 'New agent' }).click();
+  await page.getByLabel('Name').fill('Email Bot');
+  await page.getByLabel('Persona').fill('Reply politely.');
+  await page.getByLabel('Model').fill('claude-haiku-test');
+  await page.getByRole('button', { name: 'Create agent' }).click();
+
+  // Connect email opens the dialog with the inline explanation.
+  await page.getByTestId(/^connect-email-/).first().click();
+  const dialog = page.getByTestId('connect-email-dialog');
+  await expect(dialog).toBeVisible();
+  await expect(dialog).toContainText('Mailtrap');
+  await expect(dialog).toContainText('Integration');
+
+  // Fill credentials and submit.
+  await page.getByTestId('email-address').fill('agent@nexus.test');
+  await page.getByTestId('mailtrap-inbox-id').fill('inbox-1');
+  await page.getByTestId('mailtrap-account-id').fill('acc-1');
+  await page.getByTestId('mailtrap-api-token').fill('api-token-secret');
+  await page.getByTestId('mailtrap-smtp-user').fill('smtp-user');
+  await page.getByTestId('mailtrap-smtp-pass').fill('smtp-pass');
+
+  // Capture the POST so we can assert it carried the form values.
+  const responsePromise = page.waitForResponse(
+    (r) => r.url().endsWith('/api/email/channels') && r.request().method() === 'POST',
+  );
+  await dialog.getByRole('button', { name: 'Connect' }).click();
+  const res = await responsePromise;
+  expect(res.status()).toBe(201);
+
+  // Dialog closes on success.
+  await expect(page.getByTestId('connect-email-dialog')).toHaveCount(0);
+});


### PR DESCRIPTION
## Summary
- Adds the email channel: inbound via Mailtrap inbox poll + outbound via Mailtrap SMTP, sharing the runtime's session resolver so the same code path handles both directions (PRD invariant #10).
- Operator UI: per-agent "Connect email" dialog with an inline explanation of each Mailtrap credential field; the org's Mailtrap creds are stored via the credential service from #4.
- Threading: every email turn carries the wire-level Message-ID as `agent_message.external_id`, and outbound mail sets `In-Reply-To`/`References` so an operator's reply lands in the same `agent_session` as the agent's prior outbound.

## Test plan
- [x] `bun test apps/server/src/mail` — inbound→reply lands in inbox, repeat poll is idempotent (dedup), outbound→operator-reply threads into the same session
- [x] `bun test apps/server/src/routes/email.test.ts` — POST /api/email/channels stores all four Mailtrap creds + creates the channel; rejects 401/404/400
- [x] `bun run typecheck` clean across all workspaces
- [x] `bunx playwright test` — all four E2Es (auth, agents, email-connect, widget) pass

Closes #11