### PR TITLE
Fix channel schema desync — consolidate channel.address, drop dead emailAddress

### DIFF
--- a/apps/server/drizzle/0008_drop_email_address.sql
+++ b/apps/server/drizzle/0008_drop_email_address.sql
@@ -1,0 +1,21 @@
+-- Consolidate channel.email_address into channel.address. Idempotent so it
+-- repairs any environment shape: a clean post-0007 DB (column exists, holds
+-- email rows' address), a drifted dev DB (column never existed), or a halfway
+-- state. Mailtrap's inbox id is a separate identifier and stays as its own
+-- column; this also re-asserts it for envs where 0005 didn't take effect.
+
+-- Backfill must reference email_address conditionally — if the column was
+-- never created (drifted dev DB), a plain UPDATE statement parses against the
+-- live schema and would fail. Wrap in a DO block that checks first.
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_name = 'channel' AND column_name = 'email_address'
+  ) THEN
+    EXECUTE 'UPDATE "channel" SET "address" = "email_address" WHERE "address" IS NULL AND "email_address" IS NOT NULL';
+  END IF;
+END $$;
+--> statement-breakpoint
+ALTER TABLE "channel" DROP COLUMN IF EXISTS "email_address";--> statement-breakpoint
+ALTER TABLE "channel" ADD COLUMN IF NOT EXISTS "mailtrap_inbox_id" text;

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -57,6 +57,13 @@
       "when": 1777800000000,
       "tag": "0007_channel_address",
       "breakpoints": true
+    },
+    {
+      "idx": 8,
+      "version": "7",
+      "when": 1778000000000,
+      "tag": "0008_drop_email_address",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -151,11 +151,11 @@ export const knowledgePage = pgTable(
 // Channel: an addressable surface (one row per agent×channel binding). For the
 // widget, every agent installation has its own channel row; later channels
 // (SMS, voice, etc.) follow the same pattern. `address` is the channel-side
-// handle the platform owns — the Twilio phone number for SMS, etc. NULL for
-// widget channels (the widget id IS the channel id).
-//
-// `emailAddress` / `mailtrapInboxId` are email-specific holdovers from the
-// email slice; a follow-up should collapse these into `address`.
+// handle the platform owns — the Twilio phone number for SMS, the reply-from
+// email for an email channel, etc. NULL for widget channels (the widget id IS
+// the channel id). `mailtrapInboxId` is email-specific; Mailtrap's HTTP API
+// uses it as a path param for inbox polling, so it can't collapse into
+// `address`.
 export const channel = pgTable(
   'channel',
   {
@@ -168,7 +168,6 @@ export const channel = pgTable(
       .notNull()
       .references(() => agent.id, { onDelete: 'cascade' }),
     address: text('address'),
-    emailAddress: text('email_address'),
     mailtrapInboxId: text('mailtrap_inbox_id'),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
   },

--- a/apps/server/src/mail/email-channel.test.ts
+++ b/apps/server/src/mail/email-channel.test.ts
@@ -61,7 +61,7 @@ async function seedEmailChannel(): Promise<{
       orgId: o!.id,
       kind: 'email',
       agentId: a!.id,
-      emailAddress,
+      address: emailAddress,
       mailtrapInboxId: INBOX_ID,
     })
     .returning();

--- a/apps/server/src/mail/email-channel.ts
+++ b/apps/server/src/mail/email-channel.ts
@@ -32,12 +32,12 @@ export function createEmailChannel({ db, client, runtime }: EmailChannelDeps) {
       .from(channelTable)
       .where(eq(channelTable.id, channelId))
       .limit(1);
-    if (!ch || ch.kind !== 'email' || !ch.mailtrapInboxId || !ch.emailAddress) return;
+    if (!ch || ch.kind !== 'email' || !ch.mailtrapInboxId || !ch.address) return;
 
     const messages = await client.listMessages(ch.mailtrapInboxId);
     for (const msg of messages) {
       // Skip our own outbound: the inbox holds both directions in the sandbox.
-      if (msg.from === ch.emailAddress) continue;
+      if (msg.from === ch.address) continue;
 
       const inserted = await db
         .insert(channelInboundSeen)
@@ -67,10 +67,10 @@ export function createEmailChannel({ db, client, runtime }: EmailChannelDeps) {
       const reply = await runtime.invokeOverHistory(resolved);
 
       // Outbound: same `to` as the inbound's `from`, threaded via headers.
-      const outboundMessageId = generateMessageId(ch.emailAddress);
+      const outboundMessageId = generateMessageId(ch.address);
       const references = [...(msg.references ?? []), msg.messageId];
       await client.sendMail({
-        from: ch.emailAddress,
+        from: ch.address,
         to: msg.from,
         subject: replySubject(msg.subject),
         text: reply,
@@ -101,7 +101,7 @@ export function createEmailChannel({ db, client, runtime }: EmailChannelDeps) {
       .from(channelTable)
       .where(eq(channelTable.id, args.channelId))
       .limit(1);
-    if (!ch || ch.kind !== 'email' || !ch.emailAddress) {
+    if (!ch || ch.kind !== 'email' || !ch.address) {
       throw new Error(`channel not an email channel: ${args.channelId}`);
     }
 
@@ -112,9 +112,9 @@ export function createEmailChannel({ db, client, runtime }: EmailChannelDeps) {
       content: args.content,
     });
 
-    const messageId = generateMessageId(ch.emailAddress);
+    const messageId = generateMessageId(ch.address);
     await client.sendMail({
-      from: ch.emailAddress,
+      from: ch.address,
       to: args.toEmail,
       subject: args.subject ?? 'Hello',
       text: args.content,

--- a/apps/server/src/routes/agents.test.ts
+++ b/apps/server/src/routes/agents.test.ts
@@ -49,6 +49,14 @@ test('unauthenticated requests are rejected with 401', async () => {
   expect(res.status).toBe(401);
 });
 
+test('GET /api/agents returns 200 with empty list for a fresh org', async () => {
+  const cookie = await registerAndCookie('fresh@example.com');
+  const res = await app.request('/api/agents', { headers: { cookie } });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { agents: unknown[] };
+  expect(body.agents).toEqual([]);
+});
+
 test('create agent → list returns it scoped to operator org', async () => {
   const cookie = await registerAndCookie('op@example.com');
 
@@ -71,12 +79,14 @@ test('create agent → list returns it scoped to operator org', async () => {
       model: string;
       runtimeMode: string;
       voiceEnabled: boolean;
+      widgetChannelId: string | null;
     };
   };
   expect(created.agent.name).toBe('Sales Bot');
   expect(created.agent.runtimeMode).toBe('headless');
   expect(created.agent.voiceEnabled).toBe(false);
   expect(created.agent.id).toMatch(/^[0-9a-f-]{36}$/);
+  expect(created.agent.widgetChannelId).toMatch(/^[0-9a-f-]{36}$/);
 
   const list = await app.request('/api/agents', { headers: { cookie } });
   expect(list.status).toBe(200);

--- a/apps/server/src/routes/email.test.ts
+++ b/apps/server/src/routes/email.test.ts
@@ -82,7 +82,7 @@ test('POST /api/email/channels: creates channel and stores all four mailtrap cre
   const channels = await db.select().from(channel);
   expect(channels.length).toBe(1);
   expect(channels[0]!.kind).toBe('email');
-  expect(channels[0]!.emailAddress).toBe('agent@nexus.test');
+  expect(channels[0]!.address).toBe('agent@nexus.test');
   expect(channels[0]!.mailtrapInboxId).toBe('inbox-1');
 
   const credentials = createCredentialService({

--- a/apps/server/src/routes/email.ts
+++ b/apps/server/src/routes/email.ts
@@ -63,7 +63,7 @@ export function emailRoute({ db, credentials }: Deps) {
         orgId,
         kind: 'email',
         agentId: input.agentId,
-        emailAddress: input.emailAddress,
+        address: input.emailAddress,
         mailtrapInboxId: input.mailtrapInboxId,
       })
       .returning();
@@ -73,7 +73,7 @@ export function emailRoute({ db, credentials }: Deps) {
           id: created!.id,
           kind: created!.kind,
           agentId: created!.agentId,
-          emailAddress: created!.emailAddress,
+          emailAddress: created!.address,
           mailtrapInboxId: created!.mailtrapInboxId,
         },
       },


### PR DESCRIPTION
## Summary

- Drops `channel.email_address` from the Drizzle schema and replaces all reads/writes with `channel.address` (mirrors how SMS already stores its Twilio number).
- Migration 0008 backfills `address` from `email_address` if present, then drops `email_address`; idempotent (DO block + IF EXISTS) so it heals any environment shape — clean post-0007, drifted dev DB without the column, or anything in between. Re-asserts `mailtrap_inbox_id` defensively.
- `mailtrap_inbox_id` stays as its own column — Mailtrap's HTTP API uses it as a path parameter for inbox polling, so it isn't derivable from the address.
- POST /api/email/channels keeps `emailAddress` in the request body (don't break the API contract); only the storage column changes.

Closes #44

## Test plan

- [x] `bun run typecheck` clean across all workspaces
- [x] `bun test` in `apps/server` (89 pass, 0 fail) — covers `GET /api/agents` 200 / empty list, `POST /api/agents` 201 with widget channel id, `POST /api/email/channels` writing to `channel.address`, inbound polling routing through runtime with reply From == channel address, outbound-first send threading correctly
- [x] Idempotent migration verified by running test container which now applies 0000 → 0008 cleanly
- [ ] Dev stack: restart `nexus` so migrator picks up 0008, hit `/api/agents` and confirm 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)