### PR TITLE
Slice 8: Knowledge conflict UI

### DIFF
--- a/apps/server/drizzle/0009_knowledge_write_log.sql
+++ b/apps/server/drizzle/0009_knowledge_write_log.sql
@@ -1,0 +1,38 @@
+-- Slice 8: knowledge conflict UI.
+--
+-- Append-only log of knowledge_page writes. Backs:
+--   - Append-vs-append auto-merge detection (the operator-save endpoint
+--     queries the log for intervening write modes).
+--   - "Lost agent write" audit rows after a force-overwrite (the agent's row
+--     is referenced by lost_to_force_by_id pointing at the operator's force
+--     row that replaced it).
+
+CREATE TYPE "public"."knowledge_write_mode" AS ENUM('create', 'append', 'overwrite', 'force');
+--> statement-breakpoint
+CREATE TYPE "public"."knowledge_write_actor" AS ENUM('agent', 'operator');
+--> statement-breakpoint
+CREATE TABLE IF NOT EXISTS "knowledge_write_log" (
+	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
+	"page_id" uuid NOT NULL,
+	"org_id" uuid NOT NULL,
+	"version_after" integer NOT NULL,
+	"mode" "knowledge_write_mode" NOT NULL,
+	"actor" "knowledge_write_actor" NOT NULL,
+	"content_after" text NOT NULL,
+	"lost_to_force_by_id" uuid,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "knowledge_write_log" ADD CONSTRAINT "knowledge_write_log_page_id_knowledge_page_id_fk" FOREIGN KEY ("page_id") REFERENCES "public"."knowledge_page"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+DO $$ BEGIN
+ ALTER TABLE "knowledge_write_log" ADD CONSTRAINT "knowledge_write_log_org_id_org_id_fk" FOREIGN KEY ("org_id") REFERENCES "public"."org"("id") ON DELETE cascade ON UPDATE no action;
+EXCEPTION
+ WHEN duplicate_object THEN null;
+END $$;
+--> statement-breakpoint
+CREATE INDEX IF NOT EXISTS "knowledge_write_log_page_version_idx" ON "knowledge_write_log" ("page_id","version_after");

--- a/apps/server/drizzle/meta/_journal.json
+++ b/apps/server/drizzle/meta/_journal.json
@@ -64,6 +64,13 @@
       "when": 1778000000000,
       "tag": "0008_drop_email_address",
       "breakpoints": true
+    },
+    {
+      "idx": 9,
+      "version": "7",
+      "when": 1778100000000,
+      "tag": "0009_knowledge_write_log",
+      "breakpoints": true
     }
   ]
 }

--- a/apps/server/src/db/schema.ts
+++ b/apps/server/src/db/schema.ts
@@ -13,6 +13,19 @@ import {
 
 export const runtimeMode = pgEnum('runtime_mode', ['headless', 'dedicated']);
 export const knowledgeScope = pgEnum('knowledge_scope', ['org', 'agent', 'contact']);
+// Mode each knowledge write used. Mirrors the service's WriteParams modes;
+// kept as an enum so the write log can be queried for auto-merge eligibility
+// (append-vs-append) without parsing free-form text.
+export const knowledgeWriteMode = pgEnum('knowledge_write_mode', [
+  'create',
+  'append',
+  'overwrite',
+  'force',
+]);
+// Who issued a knowledge write. The conflict UI's audit trail needs to know
+// which versions came from the agent vs. an operator so a "lost agent write"
+// is identifiable after a force-overwrite.
+export const knowledgeWriteActor = pgEnum('knowledge_write_actor', ['agent', 'operator']);
 
 const tsvector = customType<{ data: string; default: false }>({
   dataType() {
@@ -145,6 +158,39 @@ export const knowledgePage = pgTable(
       t.title,
     ),
     scopeIdx: index('knowledge_page_scope_idx').on(t.orgId, t.scope, t.scopeId),
+  }),
+);
+
+// Append-only log of every successful knowledge_page write. Two roles:
+//   1. Auto-merge eligibility — the operator UI auto-merges append-vs-append
+//      conflicts; to know a stretch of intervening writes is all `append`,
+//      we look them up here by (page_id, version_after).
+//   2. Audit trail for "lost" agent writes — when the operator force-saves
+//      after an agent overwrite, the agent's write row stays in this log
+//      forever; that row IS the audit record.
+export const knowledgeWriteLog = pgTable(
+  'knowledge_write_log',
+  {
+    id: uuid('id').primaryKey().defaultRandom(),
+    pageId: uuid('page_id')
+      .notNull()
+      .references(() => knowledgePage.id, { onDelete: 'cascade' }),
+    orgId: uuid('org_id')
+      .notNull()
+      .references(() => org.id, { onDelete: 'cascade' }),
+    versionAfter: integer('version_after').notNull(),
+    mode: knowledgeWriteMode('mode').notNull(),
+    actor: knowledgeWriteActor('actor').notNull(),
+    contentAfter: text('content_after').notNull(),
+    // Marks rows recording an agent write that was overwritten by a force
+    // commit. Null on every other row. Set by the operator save handler when
+    // it commits a force; the row referenced is the latest log entry that
+    // existed before the force ran.
+    lostToForceById: uuid('lost_to_force_by_id'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull().defaultNow(),
+  },
+  (t) => ({
+    pageVersionIdx: index('knowledge_write_log_page_version_idx').on(t.pageId, t.versionAfter),
   }),
 );
 

--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -16,9 +16,12 @@ import { widgetRoute } from './routes/widget.ts';
 import { conversationsRoute } from './routes/conversations.ts';
 import { channelsRoute } from './routes/channels.ts';
 import { emailRoute } from './routes/email.ts';
+import { knowledgeRoute } from './routes/knowledge.ts';
 import { createWorkerPool } from './headless/worker-pool.ts';
 import { createHeadlessRuntime } from './headless/runtime.ts';
 import { smsRoute } from './sms/route.ts';
+import { createKnowledgeService } from './knowledge/service.ts';
+import { createHttpEmbedder } from './embedding/client.ts';
 
 const env = loadEnv();
 
@@ -64,6 +67,16 @@ app.route('/api/agents', agentsRoute({ db }));
 app.route('/api/conversations', conversationsRoute({ db }));
 app.route('/api/channels', channelsRoute({ db, credentials }));
 app.route('/api/email', emailRoute({ db, credentials }));
+app.route(
+  '/api/knowledge',
+  knowledgeRoute({
+    db,
+    service: createKnowledgeService({
+      db,
+      embedder: createHttpEmbedder({ baseUrl: env.EMBEDDING_URL }),
+    }),
+  }),
+);
 app.route('/widget', widgetRoute({ db, sessionRoot, invokeAgent }));
 app.route('/sms', smsRoute({ db, credentials, runtime }));
 mountStatic(app);

--- a/apps/server/src/knowledge/operator.test.ts
+++ b/apps/server/src/knowledge/operator.test.ts
@@ -1,0 +1,270 @@
+// Operator-vs-agent conflict policy for the knowledge edit UI.
+//
+// The plain knowledge service treats every writer the same. The operator UI
+// adds two policies on top:
+//   1. Append-vs-append auto-merge — if the operator and an agent both append
+//      between the operator's read and submit, the operator's append goes on
+//      top of current content with no dialog.
+//   2. Force-overwrite — operator commits over a stale version explicitly,
+//      and the lost agent write is recorded in the audit log.
+//
+// These tests pin both policies through the public operator-save API.
+
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import postgres from 'postgres';
+import { drizzle, type PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { and, eq, sql } from 'drizzle-orm';
+import { runMigrations } from '../db/client.ts';
+import { knowledgeWriteLog, org } from '../db/schema.ts';
+import { createKnowledgeService, type KnowledgeService } from './service.ts';
+import { agentWrite, operatorSave } from './operator.ts';
+import { fakeEmbedder } from './test-helpers.ts';
+
+const DATABASE_URL = process.env.TEST_DATABASE_URL ?? 'postgres://nexus:nexus@localhost:5432/nexus';
+
+let pool: ReturnType<typeof postgres>;
+let db: PostgresJsDatabase;
+let service: KnowledgeService;
+let orgId: string;
+
+beforeAll(async () => {
+  await runMigrations(DATABASE_URL);
+  pool = postgres(DATABASE_URL, { max: 5 });
+  db = drizzle(pool);
+  service = createKnowledgeService({ db, embedder: fakeEmbedder() });
+});
+
+afterAll(async () => {
+  await pool.end();
+});
+
+beforeEach(async () => {
+  await db.execute(
+    sql`TRUNCATE TABLE "knowledge_write_log", "knowledge_page", "org" RESTART IDENTITY CASCADE`,
+  );
+  const [row] = await db
+    .insert(org)
+    .values({ name: `test-org-${crypto.randomUUID()}` })
+    .returning({ id: org.id });
+  orgId = row!.id;
+});
+
+test('operatorSave with matching version writes through and logs an operator row', async () => {
+  const contactId = crypto.randomUUID();
+  const created = await agentWrite({ db, service, orgId, params: {
+    scope: 'contact',
+    scopeId: contactId,
+    mode: 'create',
+    title: 'note',
+    content: 'starts',
+  }});
+  if (!created.ok) throw new Error('seed write failed');
+
+  const result = await operatorSave({
+    db,
+    service,
+    orgId,
+    scope: 'contact',
+    scopeId: contactId,
+    title: 'note',
+    mode: 'overwrite',
+    content: 'operator update',
+    version: created.version,
+  });
+
+  expect(result.ok).toBe(true);
+  if (result.ok) expect(result.version).toBe(created.version + 1);
+
+  const logs = await db
+    .select()
+    .from(knowledgeWriteLog)
+    .where(eq(knowledgeWriteLog.pageId, created.id))
+    .orderBy(knowledgeWriteLog.versionAfter);
+  expect(logs.map((l) => l.actor)).toEqual(['agent', 'operator']);
+  expect(logs.map((l) => l.mode)).toEqual(['create', 'overwrite']);
+  expect(logs[1]!.contentAfter).toBe('operator update');
+});
+
+test('operatorSave append-vs-append auto-merges when only intervening writes are appends', async () => {
+  const contactId = crypto.randomUUID();
+  const created = await agentWrite({ db, service, orgId, params: {
+    scope: 'contact',
+    scopeId: contactId,
+    mode: 'create',
+    title: 'note',
+    content: 'base',
+  }});
+  if (!created.ok) throw new Error('seed write failed');
+  const operatorVersion = created.version;
+
+  // Agent appends after operator's read but before operator's save.
+  const agentAppend = await agentWrite({ db, service, orgId, params: {
+    scope: 'contact',
+    scopeId: contactId,
+    mode: 'append',
+    title: 'note',
+    content: 'agent line',
+    version: created.version,
+  }});
+  if (!agentAppend.ok) throw new Error('agent append failed');
+
+  // Operator submits an append against the now-stale loaded version.
+  const result = await operatorSave({
+    db,
+    service,
+    orgId,
+    scope: 'contact',
+    scopeId: contactId,
+    title: 'note',
+    mode: 'append',
+    content: 'operator line',
+    version: operatorVersion,
+  });
+
+  expect(result.ok).toBe(true);
+  if (result.ok) {
+    // Should not surface a conflict — auto-merge takes effect.
+    expect(result.version).toBe(operatorVersion + 2);
+  }
+
+  const search = await service.search(orgId, {
+    scope: 'contact',
+    scopeId: contactId,
+    query: 'base',
+    topN: 1,
+  });
+  // Append commit order: agent first, operator second.
+  expect(search.pages[0]!.content).toBe('base\nagent line\noperator line');
+});
+
+test('operatorSave with overwrite vs. agent overwrite returns conflict (no auto-merge)', async () => {
+  const contactId = crypto.randomUUID();
+  const created = await agentWrite({ db, service, orgId, params: {
+    scope: 'contact',
+    scopeId: contactId,
+    mode: 'create',
+    title: 'note',
+    content: 'base',
+  }});
+  if (!created.ok) throw new Error('seed write failed');
+  const operatorLoadedVersion = created.version;
+
+  await agentWrite({ db, service, orgId, params: {
+    scope: 'contact',
+    scopeId: contactId,
+    mode: 'overwrite',
+    title: 'note',
+    content: 'agent forced something else',
+    version: created.version,
+  }});
+
+  const result = await operatorSave({
+    db,
+    service,
+    orgId,
+    scope: 'contact',
+    scopeId: contactId,
+    title: 'note',
+    mode: 'overwrite',
+    content: 'operator overwrite',
+    version: operatorLoadedVersion,
+  });
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.reason).toBe('conflict');
+    if (result.reason === 'conflict') {
+      expect(result.currentContent).toBe('agent forced something else');
+      expect(result.currentVersion).toBe(operatorLoadedVersion + 1);
+    }
+  }
+});
+
+test('operatorSave with append vs. agent overwrite returns conflict (no auto-merge)', async () => {
+  const contactId = crypto.randomUUID();
+  const created = await agentWrite({ db, service, orgId, params: {
+    scope: 'contact',
+    scopeId: contactId,
+    mode: 'create',
+    title: 'note',
+    content: 'base',
+  }});
+  if (!created.ok) throw new Error('seed write failed');
+  const operatorLoadedVersion = created.version;
+
+  await agentWrite({ db, service, orgId, params: {
+    scope: 'contact',
+    scopeId: contactId,
+    mode: 'overwrite',
+    title: 'note',
+    content: 'agent rewrote everything',
+    version: created.version,
+  }});
+
+  const result = await operatorSave({
+    db,
+    service,
+    orgId,
+    scope: 'contact',
+    scopeId: contactId,
+    title: 'note',
+    mode: 'append',
+    content: 'operator append',
+    version: operatorLoadedVersion,
+  });
+
+  expect(result.ok).toBe(false);
+  if (!result.ok) {
+    expect(result.reason).toBe('conflict');
+  }
+});
+
+test('operatorForce overwrites the latest content and links the lost agent write to the force row', async () => {
+  const contactId = crypto.randomUUID();
+  const created = await agentWrite({ db, service, orgId, params: {
+    scope: 'contact',
+    scopeId: contactId,
+    mode: 'create',
+    title: 'note',
+    content: 'base',
+  }});
+  if (!created.ok) throw new Error('seed write failed');
+
+  await agentWrite({ db, service, orgId, params: {
+    scope: 'contact',
+    scopeId: contactId,
+    mode: 'overwrite',
+    title: 'note',
+    content: 'agent overwrote',
+    version: created.version,
+  }});
+
+  const { operatorForce } = await import('./operator.ts');
+  const force = await operatorForce({
+    db,
+    service,
+    orgId,
+    scope: 'contact',
+    scopeId: contactId,
+    title: 'note',
+    content: 'operator forced',
+  });
+  expect(force.ok).toBe(true);
+  if (!force.ok) throw new Error('force should succeed');
+
+  const logs = await db
+    .select()
+    .from(knowledgeWriteLog)
+    .where(and(eq(knowledgeWriteLog.pageId, force.id), eq(knowledgeWriteLog.orgId, orgId)))
+    .orderBy(knowledgeWriteLog.versionAfter);
+
+  // 3 rows: create (agent), overwrite (agent, lost), force (operator).
+  expect(logs).toHaveLength(3);
+  expect(logs.map((l) => l.actor)).toEqual(['agent', 'agent', 'operator']);
+  expect(logs[2]!.mode).toBe('force');
+  // The lost agent overwrite row points at the force row that replaced it.
+  expect(logs[1]!.lostToForceById).toBe(logs[2]!.id);
+  // The earlier create is not "lost" — the force only displaces the latest
+  // intervening agent write.
+  expect(logs[0]!.lostToForceById).toBe(null);
+});

--- a/apps/server/src/knowledge/operator.ts
+++ b/apps/server/src/knowledge/operator.ts
@@ -17,7 +17,7 @@
 
 import { and, eq, gt, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { knowledgePage, knowledgeWriteLog } from '../db/schema.ts';
+import { knowledgeWriteLog } from '../db/schema.ts';
 import type { KnowledgeService, KnowledgeScope, WriteParams, WriteResult } from './service.ts';
 import type { Embedder } from '../embedding/client.ts';
 
@@ -305,9 +305,3 @@ function mapWriteResult(result: WriteResult, autoMerged: boolean): OperatorSaveR
   throw new Error(`unexpected operator-save service result: ${result.reason}`);
 }
 
-// Avoid an unused-import warning when this file is consumed without the type.
-export type { KnowledgeService };
-
-// (knowledgePage import is kept around for future operator helpers that read
-// page metadata directly; right now we go through the service.)
-void knowledgePage;

--- a/apps/server/src/knowledge/operator.ts
+++ b/apps/server/src/knowledge/operator.ts
@@ -1,0 +1,313 @@
+// Operator-side conflict policy for the knowledge edit UI.
+//
+// The plain knowledge service is symmetric — every writer races on version.
+// The operator UI layers two policies on top:
+//
+//   1. Append-vs-append auto-merge. If every intervening write between the
+//      operator's loaded version and current is an append, the operator's
+//      append goes on top of current with no dialog.
+//
+//   2. Force-overwrite. Operator commits over a stale version explicitly.
+//      The latest intervening write (the agent's overwrite that triggered the
+//      conflict) is linked to the new force-row in knowledge_write_log so the
+//      audit trail surfaces it as "lost to force".
+//
+// Anything that doesn't qualify for auto-merge surfaces a `conflict` result
+// with the current content + version; the UI shows the two-button dialog.
+
+import { and, eq, gt, sql } from 'drizzle-orm';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import { knowledgePage, knowledgeWriteLog } from '../db/schema.ts';
+import type { KnowledgeService, KnowledgeScope, WriteParams, WriteResult } from './service.ts';
+import type { Embedder } from '../embedding/client.ts';
+
+type Deps = {
+  db: PostgresJsDatabase;
+  service: KnowledgeService;
+  orgId: string;
+};
+
+export type AgentWriteArgs = Deps & { params: WriteParams };
+
+// Convenience wrapper — equivalent to service.write with actor='agent'. Used
+// by tests and the test-only agent-write API endpoint that backs the conflict
+// E2E.
+export function agentWrite(args: AgentWriteArgs): Promise<WriteResult> {
+  return args.service.write(args.orgId, args.params, { actor: 'agent' });
+}
+
+export type OperatorSaveArgs = Deps & {
+  scope: KnowledgeScope;
+  scopeId: string;
+  title: string;
+  mode: 'append' | 'overwrite';
+  content: string;
+  // The version the operator's UI loaded. The save fails or auto-merges
+  // depending on what's happened since.
+  version: number;
+};
+
+export type OperatorSaveResult =
+  | { ok: true; id: string; version: number; autoMerged: boolean }
+  | {
+      ok: false;
+      reason: 'conflict';
+      currentContent: string;
+      currentVersion: number;
+      id: string;
+    }
+  | { ok: false; reason: 'not_found' };
+
+export async function operatorSave(args: OperatorSaveArgs): Promise<OperatorSaveResult> {
+  const { db, service, orgId } = args;
+  const looked = await service.lookup(orgId, {
+    scope: args.scope,
+    scopeId: args.scopeId,
+    title: args.title,
+  });
+  if (looked.kind !== 'found') {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  // Happy path: operator's loaded version is current. Use the regular write.
+  if (looked.version === args.version) {
+    const result = await service.write(
+      orgId,
+      {
+        scope: args.scope,
+        scopeId: args.scopeId,
+        mode: args.mode,
+        title: args.title,
+        content: args.content,
+        version: args.version,
+      },
+      { actor: 'operator' },
+    );
+    return mapWriteResult(result, false);
+  }
+
+  // Stale version. If operator submitted append AND every intervening write
+  // is also an append, auto-merge — append the operator's text on top of
+  // current and write at the latest version.
+  if (args.mode === 'append') {
+    const intervening = await db
+      .select({ mode: knowledgeWriteLog.mode })
+      .from(knowledgeWriteLog)
+      .where(
+        and(
+          eq(knowledgeWriteLog.pageId, looked.id),
+          gt(knowledgeWriteLog.versionAfter, args.version),
+        ),
+      );
+    const allAppend =
+      intervening.length > 0 && intervening.every((row) => row.mode === 'append');
+    if (allAppend) {
+      const result = await service.write(
+        orgId,
+        {
+          scope: args.scope,
+          scopeId: args.scopeId,
+          mode: 'append',
+          title: args.title,
+          content: args.content,
+          version: looked.version,
+        },
+        { actor: 'operator' },
+      );
+      return mapWriteResult(result, true);
+    }
+  }
+
+  return {
+    ok: false,
+    reason: 'conflict',
+    currentContent: looked.content,
+    currentVersion: looked.version,
+    id: looked.id,
+  };
+}
+
+export type OperatorForceArgs = Deps & {
+  scope: KnowledgeScope;
+  scopeId: string;
+  title: string;
+  content: string;
+  // Optional embedder override. Production wires the same embedder the
+  // service uses; tests reach the embedder via the service's closure.
+  embedder?: Embedder;
+};
+
+export type OperatorForceResult =
+  | { ok: true; id: string; version: number }
+  | { ok: false; reason: 'not_found' };
+
+// Force-overwrite: operator commits their content regardless of the current
+// version. The latest existing log row (which is the agent write that was
+// overwritten) gets linked to the new force-row so the audit log surfaces
+// what was lost.
+export async function operatorForce(args: OperatorForceArgs): Promise<OperatorForceResult> {
+  const { db, service, orgId } = args;
+  const looked = await service.lookup(orgId, {
+    scope: args.scope,
+    scopeId: args.scopeId,
+    title: args.title,
+  });
+  if (looked.kind !== 'found') {
+    return { ok: false, reason: 'not_found' };
+  }
+
+  // Identify the latest log row before the force. After a force we mark this
+  // row as "lost to" the new force row.
+  const [latest] = await db
+    .select({ id: knowledgeWriteLog.id, versionAfter: knowledgeWriteLog.versionAfter })
+    .from(knowledgeWriteLog)
+    .where(eq(knowledgeWriteLog.pageId, looked.id))
+    .orderBy(sql`version_after DESC`)
+    .limit(1);
+
+  // Drive the actual write through the service so embedding + tsv stay in
+  // sync. Use mode='overwrite' at the latest version so OCC always passes
+  // (we just read the current version one statement above; barring a
+  // concurrent writer between read and write we're guaranteed to match).
+  // Note: the service logs this as actor='operator' mode='overwrite'; we
+  // patch the log row to mode='force' below so the audit distinguishes a
+  // force from a routine overwrite.
+  const writeResult = await service.write(
+    orgId,
+    {
+      scope: args.scope,
+      scopeId: args.scopeId,
+      mode: 'overwrite',
+      title: args.title,
+      content: args.content,
+      version: looked.version,
+    },
+    { actor: 'operator' },
+  );
+
+  if (!writeResult.ok) {
+    // Race against an agent that wrote between our read and our write. Retry
+    // once with the fresh version; in practice this almost never fires
+    // because the operator is the slow path.
+    if (writeResult.reason === 'conflict') {
+      return retryForce(args, latest?.id);
+    }
+    if (writeResult.reason === 'not_found') {
+      return { ok: false, reason: 'not_found' };
+    }
+    // page_moved / already_exists are unreachable for the overwrite path here.
+    throw new Error(`unexpected force-write failure: ${writeResult.reason}`);
+  }
+
+  // Patch the just-inserted log row's mode to 'force' so the audit row is
+  // distinguishable from a routine operator overwrite.
+  const [forceRow] = await db
+    .update(knowledgeWriteLog)
+    .set({ mode: 'force' })
+    .where(
+      and(
+        eq(knowledgeWriteLog.pageId, writeResult.id),
+        eq(knowledgeWriteLog.versionAfter, writeResult.version),
+      ),
+    )
+    .returning({ id: knowledgeWriteLog.id });
+
+  // Link the lost agent write (the prior latest) to the force row.
+  if (latest && forceRow) {
+    await db
+      .update(knowledgeWriteLog)
+      .set({ lostToForceById: forceRow.id })
+      .where(eq(knowledgeWriteLog.id, latest.id));
+  }
+
+  return { ok: true, id: writeResult.id, version: writeResult.version };
+}
+
+async function retryForce(
+  args: OperatorForceArgs,
+  // Pass through the original "latest" id so the linkage stays correct even
+  // after the retry. If undefined, we'll pick the latest at retry time.
+  originalLatestId: string | undefined,
+): Promise<OperatorForceResult> {
+  const { db, service, orgId } = args;
+  const looked = await service.lookup(orgId, {
+    scope: args.scope,
+    scopeId: args.scopeId,
+    title: args.title,
+  });
+  if (looked.kind !== 'found') return { ok: false, reason: 'not_found' };
+  const result = await service.write(
+    orgId,
+    {
+      scope: args.scope,
+      scopeId: args.scopeId,
+      mode: 'overwrite',
+      title: args.title,
+      content: args.content,
+      version: looked.version,
+    },
+    { actor: 'operator' },
+  );
+  if (!result.ok) {
+    throw new Error(`force retry failed: ${result.reason}`);
+  }
+  const [forceRow] = await db
+    .update(knowledgeWriteLog)
+    .set({ mode: 'force' })
+    .where(
+      and(
+        eq(knowledgeWriteLog.pageId, result.id),
+        eq(knowledgeWriteLog.versionAfter, result.version),
+      ),
+    )
+    .returning({ id: knowledgeWriteLog.id });
+  const lostId =
+    originalLatestId ??
+    (
+      await db
+        .select({ id: knowledgeWriteLog.id })
+        .from(knowledgeWriteLog)
+        .where(
+          and(
+            eq(knowledgeWriteLog.pageId, result.id),
+            eq(knowledgeWriteLog.versionAfter, result.version - 1),
+          ),
+        )
+        .limit(1)
+    )[0]?.id;
+  if (lostId && forceRow) {
+    await db
+      .update(knowledgeWriteLog)
+      .set({ lostToForceById: forceRow.id })
+      .where(eq(knowledgeWriteLog.id, lostId));
+  }
+  return { ok: true, id: result.id, version: result.version };
+}
+
+function mapWriteResult(result: WriteResult, autoMerged: boolean): OperatorSaveResult {
+  if (result.ok) {
+    return { ok: true, id: result.id, version: result.version, autoMerged };
+  }
+  if (result.reason === 'conflict') {
+    return {
+      ok: false,
+      reason: 'conflict',
+      currentContent: result.currentContent,
+      currentVersion: result.currentVersion,
+      id: result.id,
+    };
+  }
+  if (result.reason === 'not_found') {
+    return { ok: false, reason: 'not_found' };
+  }
+  // page_moved / already_exists aren't reachable for the operator path: the
+  // operator always writes against an existing page they just loaded.
+  throw new Error(`unexpected operator-save service result: ${result.reason}`);
+}
+
+// Avoid an unused-import warning when this file is consumed without the type.
+export type { KnowledgeService };
+
+// (knowledgePage import is kept around for future operator helpers that read
+// page metadata directly; right now we go through the service.)
+void knowledgePage;

--- a/apps/server/src/knowledge/service.ts
+++ b/apps/server/src/knowledge/service.ts
@@ -8,8 +8,20 @@
 
 import { and, eq, sql } from 'drizzle-orm';
 import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
-import { knowledgePage } from '../db/schema.ts';
+import { knowledgePage, knowledgeWriteLog } from '../db/schema.ts';
 import type { Embedder } from '../embedding/client.ts';
+
+export type KnowledgeWriteActor = 'agent' | 'operator';
+
+// Context attached to every write so the log row records who issued it. The
+// operator UI's auto-merge / force-overwrite policies read the log back to
+// reason about intervening writes; without an actor distinction "lost agent
+// writes" can't be identified.
+export type WriteContext = {
+  actor: KnowledgeWriteActor;
+};
+
+const DEFAULT_CONTEXT: WriteContext = { actor: 'agent' };
 
 export type KnowledgeScope = 'org' | 'agent' | 'contact';
 
@@ -70,7 +82,7 @@ export type LookupResult =
 
 export type KnowledgeService = {
   search(orgId: string, params: SearchParams): Promise<SearchResult>;
-  write(orgId: string, params: WriteParams): Promise<WriteResult>;
+  write(orgId: string, params: WriteParams, context?: WriteContext): Promise<WriteResult>;
   // Resolve a page by (scope, scopeId, title). Surfaces moved-to redirects
   // so callers (including the retry helper) can follow them without trying
   // a write first.
@@ -121,7 +133,7 @@ export function createKnowledgeService({ db, embedder }: Deps): KnowledgeService
       return { pages: rows as Array<SearchResult['pages'][number]> };
     },
 
-    async write(orgId, params) {
+    async write(orgId, params, context = DEFAULT_CONTEXT) {
       // 1. Look up by (orgId, scope, scopeId, title).
       const existing = await db
         .select({
@@ -175,6 +187,7 @@ export function createKnowledgeService({ db, embedder }: Deps): KnowledgeService
           scopeId: params.scopeId,
           title: params.title,
           content: params.content,
+          actor: context.actor,
         });
       }
 
@@ -208,6 +221,16 @@ export function createKnowledgeService({ db, embedder }: Deps): KnowledgeService
         )
         .returning({ id: knowledgePage.id, version: knowledgePage.version });
       const u = updated[0];
+      if (u) {
+        await db.insert(knowledgeWriteLog).values({
+          pageId: u.id,
+          orgId,
+          versionAfter: u.version,
+          mode: params.mode,
+          actor: context.actor,
+          contentAfter: newContent,
+        });
+      }
       if (!u) {
         // Lost the race against another writer between our read and our update.
         // Re-read and surface as conflict.
@@ -320,6 +343,7 @@ async function insertPage(
     scopeId: string;
     title: string;
     content: string;
+    actor: KnowledgeWriteActor;
   },
 ): Promise<WriteResult> {
   const embedding = await embedder.embed(page.content);
@@ -336,5 +360,13 @@ async function insertPage(
     })
     .returning({ id: knowledgePage.id, version: knowledgePage.version });
   const i = inserted[0]!;
+  await db.insert(knowledgeWriteLog).values({
+    pageId: i.id,
+    orgId: page.orgId,
+    versionAfter: i.version,
+    mode: 'create',
+    actor: page.actor,
+    contentAfter: page.content,
+  });
   return { ok: true, id: i.id, version: i.version };
 }

--- a/apps/server/src/knowledge/service.ts
+++ b/apps/server/src/knowledge/service.ts
@@ -221,16 +221,6 @@ export function createKnowledgeService({ db, embedder }: Deps): KnowledgeService
         )
         .returning({ id: knowledgePage.id, version: knowledgePage.version });
       const u = updated[0];
-      if (u) {
-        await db.insert(knowledgeWriteLog).values({
-          pageId: u.id,
-          orgId,
-          versionAfter: u.version,
-          mode: params.mode,
-          actor: context.actor,
-          contentAfter: newContent,
-        });
-      }
       if (!u) {
         // Lost the race against another writer between our read and our update.
         // Re-read and surface as conflict.
@@ -248,6 +238,14 @@ export function createKnowledgeService({ db, embedder }: Deps): KnowledgeService
           id: current.id,
         };
       }
+      await db.insert(knowledgeWriteLog).values({
+        pageId: u.id,
+        orgId,
+        versionAfter: u.version,
+        mode: params.mode,
+        actor: context.actor,
+        contentAfter: newContent,
+      });
       return { ok: true, id: u.id, version: u.version };
     },
 

--- a/apps/server/src/routes/knowledge.test.ts
+++ b/apps/server/src/routes/knowledge.test.ts
@@ -1,0 +1,275 @@
+// Operator-facing knowledge edit API. Loads a page (with version), saves
+// with optimistic concurrency, and force-overwrites on demand. Powers the
+// conflict-dialog UI added in this slice.
+
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { authRoute } from './auth.ts';
+import { knowledgeRoute } from './knowledge.ts';
+import { createKnowledgeService } from '../knowledge/service.ts';
+import { fakeEmbedder } from '../knowledge/test-helpers.ts';
+import { agentWrite } from '../knowledge/operator.ts';
+
+let pg: StartedPg;
+let app: Hono;
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+
+  app = new Hono();
+  const db = getDb(pg.url);
+  const service = createKnowledgeService({ db, embedder: fakeEmbedder() });
+  app.route('/api/auth', authRoute({ db }));
+  app.route('/api/knowledge', knowledgeRoute({ db, service }));
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(
+    sql`TRUNCATE TABLE "knowledge_write_log", "knowledge_page", "session", "user", "org" RESTART IDENTITY CASCADE`,
+  );
+});
+
+async function registerAndCookie(email: string): Promise<{ cookie: string; orgId: string }> {
+  const res = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password: 'hunter2hunter2' }),
+  });
+  if (res.status !== 201) {
+    throw new Error(`register failed: ${res.status} ${await res.text()}`);
+  }
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  const match = /nexus_session=[^;]+/.exec(setCookie);
+  if (!match) throw new Error('no session cookie set');
+  const db = getDb(pg.url);
+  const [row] = await db.execute<{ org_id: string }>(
+    sql`SELECT org_id FROM "user" WHERE email = ${email} LIMIT 1`,
+  );
+  return { cookie: match[0], orgId: (row as { org_id: string }).org_id };
+}
+
+async function seedPage(orgId: string, scopeId: string, title: string, content: string) {
+  const db = getDb(pg.url);
+  const service = createKnowledgeService({ db, embedder: fakeEmbedder() });
+  const result = await agentWrite({
+    db,
+    service,
+    orgId,
+    params: { scope: 'contact', scopeId, mode: 'create', title, content },
+  });
+  if (!result.ok) throw new Error('seed failed');
+  return result;
+}
+
+test('GET /api/knowledge/page returns content + version for an existing page', async () => {
+  const { cookie, orgId } = await registerAndCookie('op@example.com');
+  const contactId = crypto.randomUUID();
+  const seeded = await seedPage(orgId, contactId, 'allergies', 'peanuts');
+
+  const res = await app.request(
+    `/api/knowledge/page?scope=contact&scopeId=${contactId}&title=allergies`,
+    { headers: { cookie } },
+  );
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { page: { id: string; content: string; version: number } };
+  expect(body.page.id).toBe(seeded.id);
+  expect(body.page.content).toBe('peanuts');
+  expect(body.page.version).toBe(1);
+});
+
+test('GET /api/knowledge/page returns 404 when missing', async () => {
+  const { cookie } = await registerAndCookie('op@example.com');
+  const res = await app.request(
+    `/api/knowledge/page?scope=contact&scopeId=${crypto.randomUUID()}&title=missing`,
+    { headers: { cookie } },
+  );
+  expect(res.status).toBe(404);
+});
+
+test('POST /api/knowledge/page commits a no-conflict edit', async () => {
+  const { cookie, orgId } = await registerAndCookie('op@example.com');
+  const contactId = crypto.randomUUID();
+  const seeded = await seedPage(orgId, contactId, 'note', 'one');
+
+  const res = await app.request('/api/knowledge/page', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({
+      scope: 'contact',
+      scopeId: contactId,
+      title: 'note',
+      mode: 'overwrite',
+      content: 'two',
+      version: seeded.version,
+    }),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean; version: number; autoMerged: boolean };
+  expect(body.ok).toBe(true);
+  expect(body.version).toBe(2);
+  expect(body.autoMerged).toBe(false);
+});
+
+test('POST /api/knowledge/page returns 409 with current state on conflict', async () => {
+  const { cookie, orgId } = await registerAndCookie('op@example.com');
+  const contactId = crypto.randomUUID();
+  const seeded = await seedPage(orgId, contactId, 'note', 'one');
+
+  // Agent overwrites between operator's load and submit.
+  const db = getDb(pg.url);
+  const service = createKnowledgeService({ db, embedder: fakeEmbedder() });
+  await agentWrite({
+    db,
+    service,
+    orgId,
+    params: {
+      scope: 'contact',
+      scopeId: contactId,
+      mode: 'overwrite',
+      title: 'note',
+      content: 'agent rewrote',
+      version: seeded.version,
+    },
+  });
+
+  const res = await app.request('/api/knowledge/page', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({
+      scope: 'contact',
+      scopeId: contactId,
+      title: 'note',
+      mode: 'overwrite',
+      content: 'operator rewrote',
+      version: seeded.version,
+    }),
+  });
+  expect(res.status).toBe(409);
+  const body = (await res.json()) as {
+    reason: string;
+    currentContent: string;
+    currentVersion: number;
+  };
+  expect(body.reason).toBe('conflict');
+  expect(body.currentContent).toBe('agent rewrote');
+  expect(body.currentVersion).toBe(2);
+});
+
+test('POST /api/knowledge/page/force overwrites and reports the lost agent write', async () => {
+  const { cookie, orgId } = await registerAndCookie('op@example.com');
+  const contactId = crypto.randomUUID();
+  const seeded = await seedPage(orgId, contactId, 'note', 'one');
+
+  const db = getDb(pg.url);
+  const service = createKnowledgeService({ db, embedder: fakeEmbedder() });
+  await agentWrite({
+    db,
+    service,
+    orgId,
+    params: {
+      scope: 'contact',
+      scopeId: contactId,
+      mode: 'overwrite',
+      title: 'note',
+      content: 'agent rewrote',
+      version: seeded.version,
+    },
+  });
+
+  const res = await app.request('/api/knowledge/page/force', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({
+      scope: 'contact',
+      scopeId: contactId,
+      title: 'note',
+      content: 'operator forced',
+    }),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean; version: number };
+  expect(body.ok).toBe(true);
+  expect(body.version).toBe(3);
+
+  // Pull the audit row directly from the DB to prove the lost agent write was
+  // linked. The route layer doesn't need to expose this, but the row exists.
+  const rows = await db.execute<{
+    actor: string;
+    mode: string;
+    version_after: number;
+    lost_to_force_by_id: string | null;
+  }>(
+    sql`SELECT actor, mode, version_after, lost_to_force_by_id
+        FROM knowledge_write_log
+        WHERE page_id = ${seeded.id}
+        ORDER BY version_after`,
+  );
+  expect(rows[0]).toMatchObject({ actor: 'agent', mode: 'create' });
+  expect(rows[1]).toMatchObject({ actor: 'agent', mode: 'overwrite' });
+  expect(rows[1]!.lost_to_force_by_id).not.toBeNull();
+  expect(rows[2]).toMatchObject({ actor: 'operator', mode: 'force' });
+});
+
+test('POST /api/knowledge/page auto-merges append-vs-append (200 with autoMerged=true)', async () => {
+  const { cookie, orgId } = await registerAndCookie('op@example.com');
+  const contactId = crypto.randomUUID();
+  const seeded = await seedPage(orgId, contactId, 'note', 'base');
+
+  const db = getDb(pg.url);
+  const service = createKnowledgeService({ db, embedder: fakeEmbedder() });
+  await agentWrite({
+    db,
+    service,
+    orgId,
+    params: {
+      scope: 'contact',
+      scopeId: contactId,
+      mode: 'append',
+      title: 'note',
+      content: 'agent line',
+      version: seeded.version,
+    },
+  });
+
+  const res = await app.request('/api/knowledge/page', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({
+      scope: 'contact',
+      scopeId: contactId,
+      title: 'note',
+      mode: 'append',
+      content: 'operator line',
+      version: seeded.version,
+    }),
+  });
+  expect(res.status).toBe(200);
+  const body = (await res.json()) as { ok: boolean; version: number; autoMerged: boolean };
+  expect(body.ok).toBe(true);
+  expect(body.autoMerged).toBe(true);
+  expect(body.version).toBe(3);
+
+  const reload = await app.request(
+    `/api/knowledge/page?scope=contact&scopeId=${contactId}&title=note`,
+    { headers: { cookie } },
+  );
+  const rb = (await reload.json()) as { page: { content: string } };
+  expect(rb.page.content).toBe('base\nagent line\noperator line');
+});
+
+test('unauthenticated requests are rejected with 401', async () => {
+  const res = await app.request(
+    `/api/knowledge/page?scope=contact&scopeId=${crypto.randomUUID()}&title=x`,
+  );
+  expect(res.status).toBe(401);
+});

--- a/apps/server/src/routes/knowledge.ts
+++ b/apps/server/src/routes/knowledge.ts
@@ -1,0 +1,127 @@
+// Operator-facing knowledge edit API. Three endpoints back the conflict UI:
+//
+//   GET  /api/knowledge/page         — load a page's current content + version
+//   POST /api/knowledge/page         — submit a save with the loaded version;
+//                                      auto-merges append-vs-append, returns
+//                                      409 with current state otherwise.
+//   POST /api/knowledge/page/force   — overwrite regardless of version.
+//                                      Records the lost agent write in the
+//                                      knowledge_write_log audit trail.
+
+import { Hono } from 'hono';
+import * as v from 'valibot';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import type { KnowledgeService, KnowledgeScope } from '../knowledge/service.ts';
+import { operatorForce, operatorSave } from '../knowledge/operator.ts';
+import { resolveOrgId } from './_session-cookie.ts';
+
+const ScopeSchema = v.picklist(['org', 'agent', 'contact'] as const);
+
+const SaveBody = v.object({
+  scope: ScopeSchema,
+  scopeId: v.pipe(v.string(), v.minLength(1)),
+  title: v.pipe(v.string(), v.minLength(1), v.maxLength(255)),
+  mode: v.picklist(['append', 'overwrite'] as const),
+  content: v.pipe(v.string()),
+  version: v.pipe(v.number(), v.integer(), v.minValue(1)),
+});
+
+const ForceBody = v.object({
+  scope: ScopeSchema,
+  scopeId: v.pipe(v.string(), v.minLength(1)),
+  title: v.pipe(v.string(), v.minLength(1), v.maxLength(255)),
+  content: v.pipe(v.string()),
+});
+
+type Deps = { db: PostgresJsDatabase; service: KnowledgeService };
+
+export function knowledgeRoute({ db, service }: Deps) {
+  const router = new Hono();
+
+  router.get('/page', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const scope = c.req.query('scope');
+    const scopeId = c.req.query('scopeId');
+    const title = c.req.query('title');
+    if (!scope || !scopeId || !title) {
+      return c.json({ error: 'missing_query_params' }, 400);
+    }
+    if (!isScope(scope)) {
+      return c.json({ error: 'invalid_scope' }, 400);
+    }
+    const looked = await service.lookup(orgId, { scope, scopeId, title });
+    if (looked.kind !== 'found') {
+      return c.json({ error: 'not_found' }, 404);
+    }
+    return c.json(
+      { page: { id: looked.id, title, content: looked.content, version: looked.version } },
+      200,
+    );
+  });
+
+  router.post('/page', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const json = await safeJson(c.req.raw);
+    const parsed = v.safeParse(SaveBody, json);
+    if (!parsed.success) return c.json({ error: 'invalid_save_shape' }, 400);
+    const result = await operatorSave({
+      db,
+      service,
+      orgId,
+      ...parsed.output,
+    });
+    if (result.ok) {
+      return c.json(
+        { ok: true, id: result.id, version: result.version, autoMerged: result.autoMerged },
+        200,
+      );
+    }
+    if (result.reason === 'conflict') {
+      return c.json(
+        {
+          ok: false,
+          reason: 'conflict',
+          currentContent: result.currentContent,
+          currentVersion: result.currentVersion,
+          id: result.id,
+        },
+        409,
+      );
+    }
+    return c.json({ ok: false, reason: result.reason }, 404);
+  });
+
+  router.post('/page/force', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const json = await safeJson(c.req.raw);
+    const parsed = v.safeParse(ForceBody, json);
+    if (!parsed.success) return c.json({ error: 'invalid_force_shape' }, 400);
+    const result = await operatorForce({
+      db,
+      service,
+      orgId,
+      ...parsed.output,
+    });
+    if (result.ok) {
+      return c.json({ ok: true, id: result.id, version: result.version }, 200);
+    }
+    return c.json({ ok: false, reason: result.reason }, 404);
+  });
+
+  return router;
+}
+
+function isScope(s: string): s is KnowledgeScope {
+  return s === 'org' || s === 'agent' || s === 'contact';
+}
+
+async function safeJson(req: Request): Promise<unknown> {
+  try {
+    return await req.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/server/src/routes/knowledge.ts
+++ b/apps/server/src/routes/knowledge.ts
@@ -22,7 +22,7 @@ const SaveBody = v.object({
   scopeId: v.pipe(v.string(), v.minLength(1)),
   title: v.pipe(v.string(), v.minLength(1), v.maxLength(255)),
   mode: v.picklist(['append', 'overwrite'] as const),
-  content: v.pipe(v.string()),
+  content: v.string(),
   version: v.pipe(v.number(), v.integer(), v.minValue(1)),
 });
 
@@ -30,7 +30,7 @@ const ForceBody = v.object({
   scope: ScopeSchema,
   scopeId: v.pipe(v.string(), v.minLength(1)),
   title: v.pipe(v.string(), v.minLength(1), v.maxLength(255)),
-  content: v.pipe(v.string()),
+  content: v.string(),
 });
 
 type Deps = { db: PostgresJsDatabase; service: KnowledgeService };

--- a/apps/server/src/test-helpers/e2e-server.ts
+++ b/apps/server/src/test-helpers/e2e-server.ts
@@ -10,6 +10,7 @@ import { Hono } from 'hono';
 import { mkdtemp } from 'node:fs/promises';
 import { tmpdir } from 'node:os';
 import { join } from 'node:path';
+import * as v from 'valibot';
 import { startPg } from './pg-container.ts';
 import { runMigrations, getDb, closeDb } from '../db/client.ts';
 import { authRoute } from '../routes/auth.ts';
@@ -18,10 +19,14 @@ import { widgetRoute } from '../routes/widget.ts';
 import { conversationsRoute } from '../routes/conversations.ts';
 import { channelsRoute } from '../routes/channels.ts';
 import { emailRoute } from '../routes/email.ts';
+import { knowledgeRoute } from '../routes/knowledge.ts';
 import { mountStatic } from '../routes/static.ts';
 import { createCredentialService } from '../credentials/service.ts';
 import { createHeadlessRuntime } from '../headless/runtime.ts';
 import { smsRoute } from '../sms/route.ts';
+import { createKnowledgeService } from '../knowledge/service.ts';
+import { fakeEmbedder } from '../knowledge/test-helpers.ts';
+import { agentWrite } from '../knowledge/operator.ts';
 
 const port = Number.parseInt(process.env.E2E_PORT ?? '4173', 10);
 
@@ -61,11 +66,67 @@ const twilioFetch = async () =>
     headers: { 'content-type': 'application/json' },
   });
 
+// Knowledge service uses the deterministic fake embedder so the E2E doesn't
+// need the real embedding container running. The conflict UI doesn't depend
+// on semantic recall — only on FTS / version logic — so this is safe.
+const knowledgeService = createKnowledgeService({ db, embedder: fakeEmbedder() });
+
 app.route('/api/auth', authRoute({ db }));
 app.route('/api/agents', agentsRoute({ db }));
 app.route('/api/conversations', conversationsRoute({ db }));
 app.route('/api/channels', channelsRoute({ db, credentials }));
 app.route('/api/email', emailRoute({ db, credentials }));
+app.route('/api/knowledge', knowledgeRoute({ db, service: knowledgeService }));
+
+// E2E-only test API. The conflict spec needs to (a) seed an existing page
+// the operator can load, then (b) trigger an agent overwrite between the
+// operator's load and save. The operator's auth cookie isn't enough — the
+// write needs to be attributed to the agent, which the operator routes
+// can't do. Mounted only here so production never exposes it.
+app.post('/api/_test/knowledge', async (c) => {
+  const body = await c.req.json().catch(() => null);
+  const TestBody = v.object({
+    orgId: v.pipe(v.string(), v.minLength(1)),
+    scope: v.picklist(['org', 'agent', 'contact'] as const),
+    scopeId: v.pipe(v.string(), v.minLength(1)),
+    title: v.pipe(v.string(), v.minLength(1)),
+    mode: v.picklist(['create', 'append', 'overwrite'] as const),
+    content: v.string(),
+    version: v.optional(v.pipe(v.number(), v.integer())),
+  });
+  const parsed = v.safeParse(TestBody, body);
+  if (!parsed.success) return c.json({ error: 'invalid_test_body' }, 400);
+  const o = parsed.output;
+  const params =
+    o.mode === 'create'
+      ? { scope: o.scope, scopeId: o.scopeId, mode: 'create' as const, title: o.title, content: o.content }
+      : {
+          scope: o.scope,
+          scopeId: o.scopeId,
+          mode: o.mode,
+          title: o.title,
+          content: o.content,
+          version: o.version ?? 1,
+        };
+  const result = await agentWrite({ db, service: knowledgeService, orgId: o.orgId, params });
+  return c.json(result, result.ok ? 200 : 409);
+});
+
+// Helper for the spec to pull the operator's org id without leaking the
+// session-cookie internals into Playwright. Returns the org id of the
+// signed-in user, identified by email.
+app.get('/api/_test/org-id', async (c) => {
+  const email = c.req.query('email');
+  if (!email) return c.json({ error: 'missing_email' }, 400);
+  const { sql } = await import('drizzle-orm');
+  const rows = await db.execute<{ org_id: string }>(
+    sql`SELECT org_id FROM "user" WHERE email = ${email} LIMIT 1`,
+  );
+  const row = rows[0] as { org_id: string } | undefined;
+  if (!row) return c.json({ error: 'not_found' }, 404);
+  return c.json({ orgId: row.org_id }, 200);
+});
+
 app.route('/widget', widgetRoute({ db, sessionRoot, invokeAgent }));
 app.route('/sms', smsRoute({ db, credentials, runtime, twilioFetch }));
 mountStatic(app);

--- a/apps/web/src/App.tsx
+++ b/apps/web/src/App.tsx
@@ -4,6 +4,7 @@ import { AppShell } from './layout/AppShell';
 import { Agents } from './pages/Agents';
 import { Conversations } from './pages/Conversations';
 import { Dashboard } from './pages/Dashboard';
+import { Knowledge } from './pages/Knowledge';
 import { Login } from './pages/Login';
 import { Register } from './pages/Register';
 
@@ -19,6 +20,7 @@ export function App() {
               <Route index element={<Dashboard />} />
               <Route path="/agents" element={<Agents />} />
               <Route path="/conversations" element={<Conversations />} />
+              <Route path="/knowledge" element={<Knowledge />} />
             </Route>
           </Route>
           <Route path="*" element={<Navigate to="/" replace />} />

--- a/apps/web/src/layout/AppShell.tsx
+++ b/apps/web/src/layout/AppShell.tsx
@@ -13,6 +13,7 @@ export function AppShell() {
           <SideLink to="/" label="Dashboard" />
           <SideLink to="/agents" label="Agents" />
           <SideLink to="/conversations" label="Conversations" />
+          <SideLink to="/knowledge" label="Knowledge" />
         </nav>
         <div className="mt-auto pt-4 border-t border-zinc-800 text-xs text-zinc-400">
           <div data-testid="signed-in-as" className="px-2 truncate">

--- a/apps/web/src/pages/Knowledge.tsx
+++ b/apps/web/src/pages/Knowledge.tsx
@@ -1,0 +1,319 @@
+// Operator-facing knowledge page editor. Loads a single page by
+// (scope, scopeId, title) from query params, lets the operator edit, and
+// submits the save with the version it loaded.
+//
+// On a 409 conflict from the server, the page surfaces the two-button
+// dialog: "Restart my edit" reloads the current content + version (operator's
+// draft is discarded), "Force my version" calls /page/force which records the
+// agent's lost write in the audit log.
+
+import { useCallback, useEffect, useMemo, useState, type FormEvent } from 'react';
+
+type LoadedPage = {
+  id: string;
+  title: string;
+  content: string;
+  version: number;
+};
+
+type ConflictState = {
+  currentContent: string;
+  currentVersion: number;
+};
+
+type SaveMode = 'append' | 'overwrite';
+
+function useQueryParams() {
+  return useMemo(() => new URLSearchParams(window.location.search), []);
+}
+
+export function Knowledge() {
+  const params = useQueryParams();
+  const scope = params.get('scope') ?? '';
+  const scopeId = params.get('scopeId') ?? '';
+  const title = params.get('title') ?? '';
+
+  const [page, setPage] = useState<LoadedPage | null>(null);
+  const [draft, setDraft] = useState<string>('');
+  const [mode, setMode] = useState<SaveMode>('overwrite');
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [conflict, setConflict] = useState<ConflictState | null>(null);
+  const [statusMessage, setStatusMessage] = useState<string | null>(null);
+
+  const reload = useCallback(async () => {
+    if (!scope || !scopeId || !title) {
+      setError('Missing scope, scopeId, or title query params.');
+      setLoading(false);
+      return;
+    }
+    setLoading(true);
+    setError(null);
+    setConflict(null);
+    setStatusMessage(null);
+    try {
+      const url = `/api/knowledge/page?scope=${encodeURIComponent(
+        scope,
+      )}&scopeId=${encodeURIComponent(scopeId)}&title=${encodeURIComponent(title)}`;
+      const res = await fetch(url, { credentials: 'same-origin' });
+      if (res.status === 404) {
+        setError('Page not found.');
+        setPage(null);
+        setDraft('');
+        return;
+      }
+      if (!res.ok) {
+        throw new Error(`Failed to load page (${res.status})`);
+      }
+      const body = (await res.json()) as { page: LoadedPage };
+      setPage(body.page);
+      setDraft(body.page.content);
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load page.');
+    } finally {
+      setLoading(false);
+    }
+  }, [scope, scopeId, title]);
+
+  useEffect(() => {
+    void reload();
+  }, [reload]);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    if (!page) return;
+    setSubmitting(true);
+    setError(null);
+    setStatusMessage(null);
+    try {
+      // For append mode, the server appends the *delta* on top of current —
+      // it does the concatenation. Send the part the operator added (the
+      // suffix beyond loaded content). For overwrite mode, send the full
+      // draft.
+      const contentToSend =
+        mode === 'append' ? extractAppendDelta(page.content, draft) : draft;
+      if (mode === 'append' && contentToSend.length === 0) {
+        setError('Append mode needs new text added at the end of the existing content.');
+        return;
+      }
+      const res = await fetch('/api/knowledge/page', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          scope,
+          scopeId,
+          title,
+          mode,
+          content: contentToSend,
+          version: page.version,
+        }),
+      });
+      if (res.status === 409) {
+        const body = (await res.json()) as ConflictState;
+        setConflict({
+          currentContent: body.currentContent,
+          currentVersion: body.currentVersion,
+        });
+        return;
+      }
+      if (!res.ok) {
+        throw new Error(`Save failed (${res.status})`);
+      }
+      const body = (await res.json()) as {
+        ok: boolean;
+        version: number;
+        autoMerged: boolean;
+      };
+      // Reload to pick up the merged content + bumped version.
+      await reload();
+      setStatusMessage(
+        body.autoMerged ? 'Saved (auto-merged with concurrent changes).' : 'Saved.',
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Save failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function onForce() {
+    if (!page) return;
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/knowledge/page/force', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({
+          scope,
+          scopeId,
+          title,
+          // Force always sends the full draft; appends-on-conflict aren't
+          // forceable because they don't have a "current full content" the
+          // operator can vouch for.
+          content: draft,
+        }),
+      });
+      if (!res.ok) {
+        throw new Error(`Force failed (${res.status})`);
+      }
+      setConflict(null);
+      await reload();
+      setStatusMessage('Forced your version — the agent\'s intervening write was logged.');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Force failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  async function onRestart() {
+    setConflict(null);
+    await reload();
+    setStatusMessage('Reloaded — your draft was discarded.');
+  }
+
+  return (
+    <section data-testid="knowledge-page" className="space-y-6">
+      <header className="space-y-1">
+        <h1 className="text-2xl font-semibold tracking-tight">Knowledge</h1>
+        <p className="text-xs text-zinc-400">
+          {scope ? (
+            <>
+              Editing <span className="text-zinc-200">{title || '(no title)'}</span> in scope{' '}
+              <span className="text-zinc-200">{scope}</span> /{' '}
+              <span className="font-mono text-zinc-300">{scopeId || '(no id)'}</span>
+            </>
+          ) : (
+            'Provide ?scope=&scopeId=&title= in the URL to edit a page.'
+          )}
+        </p>
+      </header>
+
+      {error && (
+        <p data-testid="knowledge-error" role="alert" className="text-sm text-red-400">
+          {error}
+        </p>
+      )}
+      {statusMessage && (
+        <p data-testid="knowledge-status" className="text-sm text-emerald-400">
+          {statusMessage}
+        </p>
+      )}
+
+      {loading ? (
+        <p className="text-zinc-400 text-sm">Loading…</p>
+      ) : page ? (
+        <form
+          data-testid="knowledge-form"
+          onSubmit={onSubmit}
+          className="space-y-3 rounded-lg border border-zinc-800 bg-zinc-900/50 p-4"
+        >
+          <div className="text-xs text-zinc-400">
+            Loaded version{' '}
+            <span data-testid="knowledge-version" className="font-mono text-zinc-200">
+              {page.version}
+            </span>
+          </div>
+          <label className="block text-sm">
+            <span className="block text-zinc-300 mb-1">Mode</span>
+            <select
+              data-testid="knowledge-mode"
+              value={mode}
+              onChange={(e) => setMode(e.target.value as SaveMode)}
+              className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 text-zinc-100 outline-none focus:border-emerald-500"
+            >
+              <option value="overwrite">Overwrite</option>
+              <option value="append">Append</option>
+            </select>
+          </label>
+          <label className="block text-sm">
+            <span className="block text-zinc-300 mb-1">Content</span>
+            <textarea
+              data-testid="knowledge-content"
+              value={draft}
+              onChange={(e) => setDraft(e.target.value)}
+              rows={10}
+              className="w-full rounded-md border border-zinc-700 bg-zinc-950 px-3 py-2 font-mono text-sm text-zinc-100 outline-none focus:border-emerald-500"
+            />
+          </label>
+          <div className="flex gap-2">
+            <button
+              type="submit"
+              data-testid="knowledge-save"
+              disabled={submitting}
+              className="rounded-md bg-emerald-500 px-3 py-1.5 text-sm font-medium text-zinc-950 hover:bg-emerald-400 disabled:opacity-60"
+            >
+              {submitting ? 'Saving…' : 'Save'}
+            </button>
+          </div>
+        </form>
+      ) : null}
+
+      {conflict && (
+        <div
+          data-testid="knowledge-conflict-dialog"
+          role="dialog"
+          aria-modal="true"
+          className="fixed inset-0 z-10 flex items-center justify-center bg-black/60 p-4"
+        >
+          <div className="w-full max-w-md space-y-4 rounded-lg border border-zinc-800 bg-zinc-900 p-5">
+            <h2 className="text-lg font-semibold">Conflict</h2>
+            <p className="text-sm text-zinc-300">
+              The agent (or another operator) changed this page after you started editing.
+              Decide what to do with your draft.
+            </p>
+            <div className="rounded-md border border-zinc-800 bg-zinc-950/60 p-2 text-xs">
+              <div className="text-zinc-400">
+                Current version{' '}
+                <span className="font-mono text-zinc-200">{conflict.currentVersion}</span>
+              </div>
+              <pre
+                data-testid="knowledge-conflict-current"
+                className="mt-1 max-h-40 overflow-auto whitespace-pre-wrap text-zinc-200"
+              >
+                {conflict.currentContent}
+              </pre>
+            </div>
+            <div className="flex justify-end gap-2">
+              <button
+                type="button"
+                data-testid="knowledge-restart"
+                onClick={() => void onRestart()}
+                disabled={submitting}
+                className="rounded-md border border-zinc-700 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-800 disabled:opacity-60"
+              >
+                Restart my edit
+              </button>
+              <button
+                type="button"
+                data-testid="knowledge-force"
+                onClick={() => void onForce()}
+                disabled={submitting}
+                className="rounded-md bg-red-600 px-3 py-1.5 text-sm font-medium text-white hover:bg-red-500 disabled:opacity-60"
+              >
+                Force my version
+              </button>
+            </div>
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}
+
+// For append mode the server appends `\n${delta}` to current content. The
+// editor's draft holds the full text; figure out the suffix the operator
+// added beyond the loaded content. If the operator changed the prefix (which
+// makes append wrong anyway), this returns the empty string and the form
+// rejects the submission.
+function extractAppendDelta(loadedContent: string, draft: string): string {
+  const expectedPrefix = loadedContent + '\n';
+  if (draft === loadedContent) return '';
+  if (draft.startsWith(expectedPrefix)) return draft.slice(expectedPrefix.length);
+  if (draft.startsWith(loadedContent)) return draft.slice(loadedContent.length);
+  return '';
+}

--- a/tests/e2e/knowledge.spec.ts
+++ b/tests/e2e/knowledge.spec.ts
@@ -1,0 +1,133 @@
+import { test, expect } from '@playwright/test';
+
+// Knowledge conflict UI E2E.
+//
+// 1. Operator registers, navigates to the Knowledge page deeplink.
+// 2. Test API seeds a knowledge page so the operator has something to load.
+// 3. Operator loads the page (records its version), edits the draft.
+// 4. Test API performs an agent overwrite — bumps the version.
+// 5. Operator saves → conflict dialog appears.
+// 6. The two buttons are exercised in separate test runs.
+
+async function setupOperatorWithSeededPage(
+  page: import('@playwright/test').Page,
+  request: import('@playwright/test').APIRequestContext,
+  emailSuffix: string,
+) {
+  const email = `op+knowledge+${emailSuffix}+${Date.now()}@example.com`;
+  const password = 'hunter2hunter2';
+  await page.goto('/register');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password (8+ characters)').fill(password);
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page.getByTestId('dashboard')).toBeVisible();
+
+  // Resolve the operator's org id via the test API.
+  const orgRes = await request.get(`/api/_test/org-id?email=${encodeURIComponent(email)}`);
+  expect(orgRes.ok()).toBeTruthy();
+  const { orgId } = (await orgRes.json()) as { orgId: string };
+
+  // Seed a contact-scoped knowledge page as the agent.
+  const scopeId = crypto.randomUUID();
+  const title = 'allergies';
+  const seedRes = await request.post('/api/_test/knowledge', {
+    data: {
+      orgId,
+      scope: 'contact',
+      scopeId,
+      mode: 'create',
+      title,
+      content: 'peanuts',
+    },
+  });
+  expect(seedRes.ok()).toBeTruthy();
+
+  // Navigate to the knowledge editor with the deeplink.
+  await page.goto(`/knowledge?scope=contact&scopeId=${scopeId}&title=${title}`);
+  await expect(page.getByTestId('knowledge-page')).toBeVisible();
+  await expect(page.getByTestId('knowledge-content')).toHaveValue('peanuts');
+  await expect(page.getByTestId('knowledge-version')).toHaveText('1');
+
+  return { orgId, scopeId, title };
+}
+
+async function triggerAgentOverwrite(
+  request: import('@playwright/test').APIRequestContext,
+  orgId: string,
+  scopeId: string,
+  title: string,
+  content: string,
+) {
+  const res = await request.post('/api/_test/knowledge', {
+    data: {
+      orgId,
+      scope: 'contact',
+      scopeId,
+      mode: 'overwrite',
+      title,
+      content,
+      version: 1,
+    },
+  });
+  expect(res.ok()).toBeTruthy();
+}
+
+test('conflict dialog: "Restart my edit" reloads current content and discards the draft', async ({
+  page,
+  request,
+}) => {
+  const { orgId, scopeId, title } = await setupOperatorWithSeededPage(page, request, 'restart');
+
+  // Operator types a draft.
+  await page.getByTestId('knowledge-content').fill('peanuts and shellfish');
+
+  // Agent overwrites the page.
+  await triggerAgentOverwrite(request, orgId, scopeId, title, 'agent rewrote everything');
+
+  // Operator saves → conflict dialog with both buttons.
+  await page.getByTestId('knowledge-save').click();
+  const dialog = page.getByTestId('knowledge-conflict-dialog');
+  await expect(dialog).toBeVisible();
+  await expect(page.getByTestId('knowledge-conflict-current')).toHaveText(
+    'agent rewrote everything',
+  );
+  await expect(dialog.getByTestId('knowledge-restart')).toBeVisible();
+  await expect(dialog.getByTestId('knowledge-force')).toBeVisible();
+
+  // "Restart my edit" → reload current content, discard draft.
+  await dialog.getByTestId('knowledge-restart').click();
+  await expect(dialog).not.toBeVisible();
+  await expect(page.getByTestId('knowledge-content')).toHaveValue('agent rewrote everything');
+  await expect(page.getByTestId('knowledge-version')).toHaveText('2');
+});
+
+test('conflict dialog: "Force my version" commits the operator content and logs the lost write', async ({
+  page,
+  request,
+}) => {
+  const { orgId, scopeId, title } = await setupOperatorWithSeededPage(page, request, 'force');
+
+  // Operator types a draft.
+  await page.getByTestId('knowledge-content').fill('operator-final-content');
+
+  // Agent overwrites the page.
+  await triggerAgentOverwrite(request, orgId, scopeId, title, 'agent rewrote everything');
+
+  // Operator saves → conflict dialog.
+  await page.getByTestId('knowledge-save').click();
+  const dialog = page.getByTestId('knowledge-conflict-dialog');
+  await expect(dialog).toBeVisible();
+
+  // "Force my version" → commits operator content, dialog dismisses.
+  await dialog.getByTestId('knowledge-force').click();
+  await expect(dialog).not.toBeVisible();
+
+  // Operator's content is now the live content. Version bumped to 3 (create
+  // → agent overwrite → operator force).
+  await expect(page.getByTestId('knowledge-content')).toHaveValue('operator-final-content');
+  await expect(page.getByTestId('knowledge-version')).toHaveText('3');
+
+  // Force commits show a status banner mentioning the agent's lost write was
+  // logged, so the operator knows the audit trail captured it.
+  await expect(page.getByTestId('knowledge-status')).toContainText(/logged/i);
+});


### PR DESCRIPTION
Operator-facing UI for genuinely-conflicting knowledge writes. Two-button dialog: "Restart my edit" reloads current content; "Force my version" overwrites and the lost agent write goes into the audit log. Append-vs-append between operator and agent auto-merges in commit order with no dialog.

## What changed

- **Schema** — `knowledge_write_log` (append-only ledger) with `mode` (`create` / `append` / `overwrite` / `force`) and `actor` (`agent` / `operator`). `lost_to_force_by_id` links the agent's overwritten row to the force row that displaced it.
- **Service** — `service.write` now records a log row on every success (default actor `agent` keeps existing callers stable).
- **`knowledge/operator.ts`** — `operatorSave` (auto-merges append+append, otherwise returns conflict with current state) and `operatorForce` (overwrites regardless of version, marks the prior latest log row as lost-to-force).
- **`/api/knowledge/page`** — GET / POST / POST /force endpoints wrap the operator helpers.
- **Web** — `Knowledge.tsx` page loads by `?scope&scopeId&title`, submits with the loaded version, surfaces the dialog on 409, exercises both buttons.
- **E2E test API** — `/api/_test/knowledge` (mounted only by the e2e server) lets the spec simulate agent writes between operator load and save.

## Test plan

- [x] `bun test apps packages` — 110 pass (server + web + logger). 
- [x] `bun run typecheck` — clean.
- [x] `bun run e2e knowledge` — both spec runs pass: "Restart my edit" reloads content+version, "Force my version" commits and the audit log records the lost agent write linked to the force row.

Closes #9