### PR TITLE
Slice 11: Telegram (1-on-1)

### DIFF
--- a/apps/server/src/index.ts
+++ b/apps/server/src/index.ts
@@ -19,6 +19,7 @@ import { emailRoute } from './routes/email.ts';
 import { createWorkerPool } from './headless/worker-pool.ts';
 import { createHeadlessRuntime } from './headless/runtime.ts';
 import { smsRoute } from './sms/route.ts';
+import { telegramRoute } from './telegram/route.ts';
 
 const env = loadEnv();
 
@@ -66,6 +67,7 @@ app.route('/api/channels', channelsRoute({ db, credentials }));
 app.route('/api/email', emailRoute({ db, credentials }));
 app.route('/widget', widgetRoute({ db, sessionRoot, invokeAgent }));
 app.route('/sms', smsRoute({ db, credentials, runtime }));
+app.route('/telegram', telegramRoute({ db, credentials, runtime }));
 mountStatic(app);
 
 const server = Bun.serve({

--- a/apps/server/src/routes/agents.ts
+++ b/apps/server/src/routes/agents.ts
@@ -102,6 +102,8 @@ function toApi(row: AgentRow, channels: ChannelRow[]) {
   // without filtering on its end.
   const widget = channels.find((c) => c.kind === 'widget' && c.agentId === row.id) ?? null;
   const sms = channels.find((c) => c.kind === 'sms' && c.agentId === row.id) ?? null;
+  const telegram =
+    channels.find((c) => c.kind === 'telegram' && c.agentId === row.id) ?? null;
   return {
     id: row.id,
     name: row.name,
@@ -111,6 +113,7 @@ function toApi(row: AgentRow, channels: ChannelRow[]) {
     voiceEnabled: row.voiceEnabled,
     widgetChannelId: widget?.id ?? null,
     smsChannel: sms ? { id: sms.id, phoneNumber: sms.address ?? '' } : null,
+    telegramChannel: telegram ? { id: telegram.id, botId: telegram.address ?? '' } : null,
   };
 }
 

--- a/apps/server/src/routes/channels.test.ts
+++ b/apps/server/src/routes/channels.test.ts
@@ -159,3 +159,91 @@ test('POST /api/channels/sms: refuses to attach the same number twice', async ()
   });
   expect(second.status).toBe(409);
 });
+
+test('POST /api/channels/telegram: stores bot token + creates Telegram channel', async () => {
+  const { cookie } = await register();
+  const agentId = await createAgent(cookie);
+
+  const res = await app.request('/api/channels/telegram', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({ agentId, botToken: '123456:ABCdefGHIjkl' }),
+  });
+  expect(res.status).toBe(201);
+  const body = (await res.json()) as {
+    channel: { id: string; kind: string; address: string; agentId: string };
+  };
+  expect(body.channel.kind).toBe('telegram');
+  // Bot id (the digits before the colon) is stored as the channel address so
+  // the public webhook can resolve the channel without trusting a path param.
+  expect(body.channel.address).toBe('123456');
+
+  // Bot token round-trips through the credential store.
+  const db = getDb(pg.url);
+  const credentials = createCredentialService({ db, encryptionKey: ENCRYPTION_KEY });
+  const channels = await db.execute<{ org_id: string }>(
+    sql`SELECT org_id FROM "channel" WHERE id = ${body.channel.id}`,
+  );
+  expect(await credentials.get(channels[0]!.org_id, 'telegram', 'bot_token')).toBe(
+    '123456:ABCdefGHIjkl',
+  );
+});
+
+test('POST /api/channels/telegram: 401 when not authenticated', async () => {
+  const res = await app.request('/api/channels/telegram', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      agentId: '00000000-0000-0000-0000-000000000000',
+      botToken: '1:t',
+    }),
+  });
+  expect(res.status).toBe(401);
+});
+
+test('POST /api/channels/telegram: 400 for malformed bot token', async () => {
+  const { cookie } = await register();
+  const agentId = await createAgent(cookie);
+
+  const res = await app.request('/api/channels/telegram', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({ agentId, botToken: 'not-a-bot-token' }),
+  });
+  expect(res.status).toBe(400);
+});
+
+test('POST /api/channels/telegram: 404 when agent belongs to another org', async () => {
+  const { cookie: cookieA } = await register();
+  const db = getDb(pg.url);
+  const [orgB] = await db.execute<{ id: string }>(
+    sql`INSERT INTO org (name) VALUES ('B') RETURNING id`,
+  );
+  const [agB] = await db.execute<{ id: string }>(
+    sql`INSERT INTO agent (org_id, name, persona, model) VALUES (${orgB!.id}, 'b', 'p', 'm') RETURNING id`,
+  );
+
+  const res = await app.request('/api/channels/telegram', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie: cookieA },
+    body: JSON.stringify({ agentId: agB!.id, botToken: '777:zzz' }),
+  });
+  expect(res.status).toBe(404);
+});
+
+test('POST /api/channels/telegram: refuses to attach the same bot twice', async () => {
+  const { cookie } = await register();
+  const agentId = await createAgent(cookie);
+  const first = await app.request('/api/channels/telegram', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({ agentId, botToken: '424242:firstcopy' }),
+  });
+  expect(first.status).toBe(201);
+  const second = await app.request('/api/channels/telegram', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({ agentId, botToken: '424242:secondcopy' }),
+  });
+  expect(second.status).toBe(409);
+});

--- a/apps/server/src/routes/channels.ts
+++ b/apps/server/src/routes/channels.ts
@@ -6,9 +6,14 @@
 //   - inserts an SMS `channel` row keyed on the phone number for inbound
 //     resolution.
 //
-// The operator UI uses this endpoint to wire up SMS. The Twilio webhook URL
-// the operator pastes into Twilio's console points at the public
-// `/sms/twilio/inbound` route.
+// `POST /api/channels/telegram` connects a Telegram bot to an agent:
+//   - persists `telegram.bot_token` in the per-org credential store,
+//   - inserts a Telegram `channel` row keyed on the bot id (the integer
+//     prefix of the token) for inbound resolution.
+//
+// The operator UI uses these endpoints to wire up SMS / Telegram. The webhook
+// URL the operator pastes into the provider's console points at the public
+// inbound route (`/sms/twilio/inbound`, `/telegram/webhook/<botId>`).
 
 import { Hono } from 'hono';
 import * as v from 'valibot';
@@ -17,6 +22,7 @@ import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
 import { agent as agentTable, channel as channelTable } from '../db/schema.ts';
 import type { CredentialService } from '../credentials/service.ts';
 import { resolveOrgId } from './_session-cookie.ts';
+import { botIdFromToken } from '../telegram/telegram.ts';
 
 type Deps = {
   db: PostgresJsDatabase;
@@ -29,6 +35,14 @@ const SmsBody = v.object({
   twilioAuthToken: v.pipe(v.string(), v.minLength(1), v.maxLength(256)),
   // E.164-ish: leading + then digits. Generous on length; Twilio enforces.
   phoneNumber: v.pipe(v.string(), v.regex(/^\+[1-9]\d{1,14}$/)),
+});
+
+const TelegramBody = v.object({
+  agentId: v.pipe(v.string(), v.uuid()),
+  // Telegram bot tokens look like `<digits>:<auth>`. We re-validate the bot id
+  // can be parsed below; this regex blocks the obviously malformed ones up
+  // front.
+  botToken: v.pipe(v.string(), v.regex(/^\d+:[A-Za-z0-9_-]+$/), v.maxLength(256)),
 });
 
 export function channelsRoute({ db, credentials }: Deps) {
@@ -67,6 +81,53 @@ export function channelsRoute({ db, credentials }: Deps) {
     const [created] = await db
       .insert(channelTable)
       .values({ orgId, kind: 'sms', agentId, address: phoneNumber })
+      .returning();
+    return c.json(
+      {
+        channel: {
+          id: created!.id,
+          kind: created!.kind,
+          address: created!.address,
+          agentId: created!.agentId,
+        },
+      },
+      201,
+    );
+  });
+
+  router.post('/telegram', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const json = await safeJson(c.req.raw);
+    const parsed = v.safeParse(TelegramBody, json);
+    if (!parsed.success) return c.json({ error: 'invalid_telegram_channel_shape' }, 400);
+
+    const { agentId, botToken } = parsed.output;
+    const botId = botIdFromToken(botToken);
+    if (!botId) return c.json({ error: 'invalid_telegram_channel_shape' }, 400);
+
+    const [a] = await db
+      .select()
+      .from(agentTable)
+      .where(and(eq(agentTable.id, agentId), eq(agentTable.orgId, orgId)))
+      .limit(1);
+    if (!a) return c.json({ error: 'agent_not_found' }, 404);
+
+    // Bot id is unique across Telegram, and we key the channel on it so the
+    // public webhook can resolve without touching the secret token. The
+    // (kind, address) unique index also enforces this at the DB level.
+    const [existing] = await db
+      .select({ id: channelTable.id })
+      .from(channelTable)
+      .where(and(eq(channelTable.kind, 'telegram'), eq(channelTable.address, botId)))
+      .limit(1);
+    if (existing) return c.json({ error: 'telegram_bot_in_use' }, 409);
+
+    await credentials.set(orgId, 'telegram', 'bot_token', botToken);
+
+    const [created] = await db
+      .insert(channelTable)
+      .values({ orgId, kind: 'telegram', agentId, address: botId })
       .returning();
     return c.json(
       {

--- a/apps/server/src/telegram/inbound.test.ts
+++ b/apps/server/src/telegram/inbound.test.ts
@@ -16,8 +16,6 @@ import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
 import { agent, channel, org } from '../db/schema.ts';
 import { createHeadlessRuntime } from '../headless/runtime.ts';
 import { createCredentialService } from '../credentials/service.ts';
-import { authRoute } from '../routes/auth.ts';
-import { conversationsRoute } from '../routes/conversations.ts';
 import { telegramRoute } from './route.ts';
 import type { FetchLike } from './telegram.ts';
 
@@ -60,8 +58,6 @@ beforeAll(async () => {
     });
   };
 
-  app.route('/api/auth', authRoute({ db }));
-  app.route('/api/conversations', conversationsRoute({ db }));
   app.route('/telegram', telegramRoute({ db, credentials, runtime, telegramFetch }));
 }, 120_000);
 

--- a/apps/server/src/telegram/inbound.test.ts
+++ b/apps/server/src/telegram/inbound.test.ts
@@ -1,0 +1,192 @@
+// POST /telegram/webhook/:botId — Telegram bot webhook for 1-on-1 chats.
+//
+// Resolves the channel from the bot id, dispatches the inbound user message
+// through the same headless runtime the widget + SMS channels use, then
+// sends the agent's reply back via the Telegram bot API. Group chats are
+// out of scope at v1.0 — non-private updates are dropped.
+
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { agent, channel, org } from '../db/schema.ts';
+import { createHeadlessRuntime } from '../headless/runtime.ts';
+import { createCredentialService } from '../credentials/service.ts';
+import { authRoute } from '../routes/auth.ts';
+import { conversationsRoute } from '../routes/conversations.ts';
+import { telegramRoute } from './route.ts';
+import type { FetchLike } from './telegram.ts';
+
+const ENCRYPTION_KEY = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=';
+const BOT_TOKEN = '123456:ABCdefGHIjklMNOpqr';
+const BOT_ID = '123456';
+
+let pg: StartedPg;
+let app: Hono;
+let sessionRoot: string;
+let sentMessages: Array<{ token: string; chatId: number; text: string }>;
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+  sessionRoot = await mkdtemp(join(tmpdir(), 'nexus-tg-rt-'));
+
+  app = new Hono();
+  const db = getDb(pg.url);
+  sentMessages = [];
+  const credentials = createCredentialService({ db, encryptionKey: ENCRYPTION_KEY });
+  const runtime = createHeadlessRuntime({
+    db,
+    sessionRoot,
+    invokeAgent: async (_opts, history) => {
+      const last = history[history.length - 1]!;
+      return `echo:${last.content}`;
+    },
+  });
+
+  const telegramFetch: FetchLike = async (url, init) => {
+    // URL is `https://api.telegram.org/bot{token}/sendMessage`. Pull the
+    // token out so the test can confirm the call used the right one.
+    const token = /\/bot([^/]+)\/sendMessage/.exec(url)?.[1] ?? '';
+    const json = JSON.parse(String(init.body ?? '{}')) as { chat_id: number; text: string };
+    sentMessages.push({ token, chatId: json.chat_id, text: json.text });
+    return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  app.route('/api/auth', authRoute({ db }));
+  app.route('/api/conversations', conversationsRoute({ db }));
+  app.route('/telegram', telegramRoute({ db, credentials, runtime, telegramFetch }));
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+  await rm(sessionRoot, { recursive: true, force: true });
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(
+    sql`TRUNCATE TABLE "agent_message", "agent_session", "identifier", "contact", "channel", "credential", "agent", "session", "user", "org" RESTART IDENTITY CASCADE`,
+  );
+  sentMessages.length = 0;
+});
+
+async function seedTelegramChannel(): Promise<{ orgId: string; channelId: string }> {
+  const db = getDb(pg.url);
+  const credentials = createCredentialService({ db, encryptionKey: ENCRYPTION_KEY });
+  const [o] = await db.insert(org).values({ name: 'o' }).returning();
+  const [a] = await db
+    .insert(agent)
+    .values({ orgId: o!.id, name: 'a', persona: 'p', model: 'm' })
+    .returning();
+  const [ch] = await db
+    .insert(channel)
+    .values({ orgId: o!.id, kind: 'telegram', agentId: a!.id, address: BOT_ID })
+    .returning();
+  await credentials.set(o!.id, 'telegram', 'bot_token', BOT_TOKEN);
+  return { orgId: o!.id, channelId: ch!.id };
+}
+
+function inboundUpdate(opts: {
+  updateId: number;
+  fromId: number;
+  chatId: number;
+  text: string;
+  chatType?: 'private' | 'group' | 'supergroup' | 'channel';
+  isBot?: boolean;
+}) {
+  return {
+    update_id: opts.updateId,
+    message: {
+      message_id: opts.updateId,
+      from: { id: opts.fromId, is_bot: opts.isBot ?? false, first_name: 'V' },
+      chat: { id: opts.chatId, type: opts.chatType ?? 'private' },
+      date: 1700000000,
+      text: opts.text,
+    },
+  };
+}
+
+test('inbound: dispatches to agent, sends reply via Telegram bot API', async () => {
+  await seedTelegramChannel();
+
+  const res = await app.request(`/telegram/webhook/${BOT_ID}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(
+      inboundUpdate({ updateId: 100, fromId: 555, chatId: 555, text: 'hello there' }),
+    ),
+  });
+  expect(res.status).toBe(200);
+
+  expect(sentMessages).toHaveLength(1);
+  expect(sentMessages[0]!.token).toBe(BOT_TOKEN);
+  expect(sentMessages[0]!.chatId).toBe(555);
+  expect(sentMessages[0]!.text).toBe('echo:hello there');
+});
+
+test('inbound: same sender twice reuses the same agent session', async () => {
+  const { orgId } = await seedTelegramChannel();
+  await app.request(`/telegram/webhook/${BOT_ID}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(
+      inboundUpdate({ updateId: 1, fromId: 777, chatId: 777, text: 'one' }),
+    ),
+  });
+  await app.request(`/telegram/webhook/${BOT_ID}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(
+      inboundUpdate({ updateId: 2, fromId: 777, chatId: 777, text: 'two' }),
+    ),
+  });
+
+  const db = getDb(pg.url);
+  const sessions = await db.execute<{ id: string }>(
+    sql`SELECT id FROM agent_session WHERE org_id = ${orgId}`,
+  );
+  expect(sessions.length).toBe(1);
+});
+
+test('inbound: drops non-private chats (groups deferred to v1.1+)', async () => {
+  await seedTelegramChannel();
+
+  const res = await app.request(`/telegram/webhook/${BOT_ID}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(
+      inboundUpdate({
+        updateId: 50,
+        fromId: 1,
+        chatId: -100,
+        text: 'group msg',
+        chatType: 'supergroup',
+      }),
+    ),
+  });
+  // Acknowledge so Telegram doesn't retry, but no agent dispatch + no reply.
+  expect(res.status).toBe(200);
+  expect(sentMessages).toHaveLength(0);
+});
+
+test('inbound: 404 when bot id is not provisioned for any channel', async () => {
+  await seedTelegramChannel();
+  const res = await app.request(`/telegram/webhook/999999`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify(
+      inboundUpdate({ updateId: 1, fromId: 1, chatId: 1, text: 'hi' }),
+    ),
+  });
+  expect(res.status).toBe(404);
+  expect(sentMessages).toHaveLength(0);
+});

--- a/apps/server/src/telegram/outbound.test.ts
+++ b/apps/server/src/telegram/outbound.test.ts
@@ -1,0 +1,220 @@
+// POST /telegram/send: operator-authenticated outbound proactive Telegram send.
+//
+// PRD invariant #10: outbound and inbound resolve through the same
+// `resolveSession` code path, so when a contact replies, the inbound webhook
+// finds the same session — proactive sends and the contact's reply share
+// one thread.
+
+import { test, expect, beforeAll, afterAll, beforeEach } from 'bun:test';
+import { Hono } from 'hono';
+import { sql } from 'drizzle-orm';
+import { mkdtemp, rm } from 'node:fs/promises';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { runMigrations, getDb, closeDb } from '../db/client.ts';
+import { startPg, type StartedPg } from '../test-helpers/pg-container.ts';
+import { agent, channel, contact, identifier, org } from '../db/schema.ts';
+import { createHeadlessRuntime } from '../headless/runtime.ts';
+import { createCredentialService } from '../credentials/service.ts';
+import { authRoute } from '../routes/auth.ts';
+import { conversationsRoute } from '../routes/conversations.ts';
+import { telegramRoute } from './route.ts';
+import type { FetchLike } from './telegram.ts';
+
+const ENCRYPTION_KEY = 'AAECAwQFBgcICQoLDA0ODxAREhMUFRYXGBkaGxwdHh8=';
+const BOT_TOKEN = '987654:OutboundXYZ';
+const BOT_ID = '987654';
+
+let pg: StartedPg;
+let app: Hono;
+let sessionRoot: string;
+let sentMessages: Array<{ chatId: number; text: string }>;
+
+beforeAll(async () => {
+  pg = await startPg();
+  await runMigrations(pg.url);
+  sessionRoot = await mkdtemp(join(tmpdir(), 'nexus-tg-out-'));
+
+  app = new Hono();
+  const db = getDb(pg.url);
+  sentMessages = [];
+  const credentials = createCredentialService({ db, encryptionKey: ENCRYPTION_KEY });
+  const runtime = createHeadlessRuntime({
+    db,
+    sessionRoot,
+    invokeAgent: async (_opts, history) => {
+      const last = history[history.length - 1]!;
+      return `echo:${last.content}`;
+    },
+  });
+
+  const telegramFetch: FetchLike = async (_url, init) => {
+    const json = JSON.parse(String(init.body ?? '{}')) as { chat_id: number; text: string };
+    sentMessages.push({ chatId: json.chat_id, text: json.text });
+    return new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), {
+      status: 200,
+      headers: { 'content-type': 'application/json' },
+    });
+  };
+
+  app.route('/api/auth', authRoute({ db }));
+  app.route('/api/conversations', conversationsRoute({ db }));
+  app.route('/telegram', telegramRoute({ db, credentials, runtime, telegramFetch }));
+}, 120_000);
+
+afterAll(async () => {
+  await closeDb();
+  await pg.stop();
+  await rm(sessionRoot, { recursive: true, force: true });
+}, 60_000);
+
+beforeEach(async () => {
+  const db = getDb(pg.url);
+  await db.execute(
+    sql`TRUNCATE TABLE "agent_message", "agent_session", "identifier", "contact", "channel", "credential", "agent", "session", "user", "org" RESTART IDENTITY CASCADE`,
+  );
+  sentMessages.length = 0;
+});
+
+async function registerOperator(): Promise<{ orgId: string; cookie: string }> {
+  const res = await app.request('/api/auth/register', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      email: `op+${crypto.randomUUID()}@example.com`,
+      password: 'hunter2hunter2',
+    }),
+  });
+  const setCookie = res.headers.get('set-cookie') ?? '';
+  const cookie = /nexus_session=[^;]+/.exec(setCookie)![0];
+  const db = getDb(pg.url);
+  const [row] = await db.execute<{ id: string }>(sql`SELECT id FROM org LIMIT 1`);
+  return { orgId: row!.id, cookie };
+}
+
+async function seedChannelAndContact(orgId: string, telegramUserId: string) {
+  const db = getDb(pg.url);
+  const credentials = createCredentialService({ db, encryptionKey: ENCRYPTION_KEY });
+  const [a] = await db
+    .insert(agent)
+    .values({ orgId, name: 'a', persona: 'p', model: 'm' })
+    .returning();
+  const [ch] = await db
+    .insert(channel)
+    .values({ orgId, kind: 'telegram', agentId: a!.id, address: BOT_ID })
+    .returning();
+  await credentials.set(orgId, 'telegram', 'bot_token', BOT_TOKEN);
+
+  const [con] = await db.insert(contact).values({ orgId }).returning();
+  await db
+    .insert(identifier)
+    .values({ contactId: con!.id, kind: 'telegram_user_id', value: telegramUserId });
+  return { channelId: ch!.id, contactId: con!.id };
+}
+
+test('outbound + reply: both turns in the same session', async () => {
+  const { orgId, cookie } = await registerOperator();
+  const telegramUserId = '424242';
+  const { channelId, contactId } = await seedChannelAndContact(orgId, telegramUserId);
+
+  // 1. Operator sends outbound proactive Telegram message.
+  const outboundRes = await app.request('/telegram/send', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({ channelId, contactId, content: 'Hi from us' }),
+  });
+  expect(outboundRes.status).toBe(200);
+  const outbound = (await outboundRes.json()) as { sessionId: string };
+
+  // Telegram call captured: chat id is the contact's telegram user id.
+  expect(sentMessages).toHaveLength(1);
+  expect(sentMessages[0]!.text).toBe('Hi from us');
+  expect(sentMessages[0]!.chatId).toBe(424242);
+
+  // 2. Contact replies — Telegram inbound webhook fires.
+  const inboundRes = await app.request(`/telegram/webhook/${BOT_ID}`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      update_id: 1,
+      message: {
+        message_id: 1,
+        from: { id: 424242, is_bot: false },
+        chat: { id: 424242, type: 'private' },
+        date: 1700000001,
+        text: 'thanks',
+      },
+    }),
+  });
+  expect(inboundRes.status).toBe(200);
+
+  // 3. Both messages land in the SAME session.
+  const detail = await app.request(`/api/conversations/${outbound.sessionId}`, {
+    headers: { cookie },
+  });
+  expect(detail.status).toBe(200);
+  const body = (await detail.json()) as {
+    conversation: { messages: Array<{ role: string; content: string }> };
+  };
+  // Outbound assistant message, then inbound user message, then echoed agent reply.
+  expect(body.conversation.messages.map((m) => `${m.role}:${m.content}`)).toEqual([
+    'assistant:Hi from us',
+    'user:thanks',
+    'assistant:echo:thanks',
+  ]);
+});
+
+test('outbound: 401 when not authenticated', async () => {
+  const res = await app.request('/telegram/send', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({
+      channelId: '00000000-0000-0000-0000-000000000000',
+      contactId: '00000000-0000-0000-0000-000000000000',
+      content: 'x',
+    }),
+  });
+  expect(res.status).toBe(401);
+});
+
+test('outbound: 404 when channel belongs to another org', async () => {
+  const { cookie: cookieA } = await registerOperator();
+
+  // Another org's Telegram channel.
+  const db = getDb(pg.url);
+  const [orgB] = await db.insert(org).values({ name: 'B' }).returning();
+  const [agB] = await db
+    .insert(agent)
+    .values({ orgId: orgB!.id, name: 'b', persona: 'p', model: 'm' })
+    .returning();
+  const [chB] = await db
+    .insert(channel)
+    .values({ orgId: orgB!.id, kind: 'telegram', agentId: agB!.id, address: '111222' })
+    .returning();
+  const [conB] = await db.insert(contact).values({ orgId: orgB!.id }).returning();
+  await db
+    .insert(identifier)
+    .values({ contactId: conB!.id, kind: 'telegram_user_id', value: '99' });
+
+  const res = await app.request('/telegram/send', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie: cookieA },
+    body: JSON.stringify({ channelId: chB!.id, contactId: conB!.id, content: 'x' }),
+  });
+  expect(res.status).toBe(404);
+});
+
+test('outbound: 409 when contact has do_not_contact set', async () => {
+  const { orgId, cookie } = await registerOperator();
+  const { channelId, contactId } = await seedChannelAndContact(orgId, '525252');
+  const db = getDb(pg.url);
+  await db.execute(sql`UPDATE contact SET do_not_contact = true WHERE id = ${contactId}`);
+
+  const res = await app.request('/telegram/send', {
+    method: 'POST',
+    headers: { 'content-type': 'application/json', cookie },
+    body: JSON.stringify({ channelId, contactId, content: 'x' }),
+  });
+  expect(res.status).toBe(409);
+  expect(sentMessages).toHaveLength(0);
+});

--- a/apps/server/src/telegram/route.ts
+++ b/apps/server/src/telegram/route.ts
@@ -1,0 +1,172 @@
+// Telegram channel routes:
+//   - POST /telegram/webhook/:botId — Telegram bot webhook for inbound updates.
+//   - POST /telegram/send             — operator-authenticated outbound send.
+//
+// Inbound: Telegram POSTs an Update; we resolve the channel by bot id (from
+// the URL), look up the org's stored bot token, dispatch the user turn through
+// the same headless runtime the widget uses, then send the agent's reply
+// back through the Telegram bot API. 1-on-1 only at v1.0 — non-private chats
+// are dropped.
+//
+// Outbound: looks up the contact's `telegram_user_id` identifier and routes
+// through the runtime's outbound helper (PRD invariant #10 — same code path
+// as inbound, so reply continuity is automatic).
+
+import { Hono } from 'hono';
+import { and, eq } from 'drizzle-orm';
+import * as v from 'valibot';
+import type { PostgresJsDatabase } from 'drizzle-orm/postgres-js';
+import {
+  channel as channelTable,
+  contact as contactTable,
+  identifier as identifierTable,
+} from '../db/schema.ts';
+import type { CredentialService } from '../credentials/service.ts';
+import type { HeadlessRuntime } from '../headless/runtime.ts';
+import { resolveOrgId } from '../routes/_session-cookie.ts';
+import { sendTelegramMessage, type FetchLike } from './telegram.ts';
+
+type Deps = {
+  db: PostgresJsDatabase;
+  credentials: CredentialService;
+  runtime: HeadlessRuntime;
+  telegramFetch?: FetchLike;
+};
+
+const SendBody = v.object({
+  channelId: v.pipe(v.string(), v.uuid()),
+  contactId: v.pipe(v.string(), v.uuid()),
+  content: v.pipe(v.string(), v.minLength(1), v.maxLength(4096)),
+});
+
+export function telegramRoute({ db, credentials, runtime, telegramFetch }: Deps) {
+  const router = new Hono();
+
+  router.post('/webhook/:botId', async (c) => {
+    const botId = c.req.param('botId');
+    const update = (await safeJson(c.req.raw)) as TelegramUpdate | null;
+    const message = update?.message;
+    const from = message?.from;
+    if (!message || !from || from.is_bot) {
+      // Edits, callbacks, bot-to-bot relays, anonymous-channel posts — out of
+      // scope for the 1-on-1 text path. Acknowledge so Telegram stops retrying.
+      return c.json({ ok: true }, 200);
+    }
+    if (message.chat.type !== 'private') {
+      // Group chats deferred to v1.1+.
+      return c.json({ ok: true }, 200);
+    }
+    if (typeof message.text !== 'string' || message.text.length === 0) {
+      return c.json({ ok: true }, 200);
+    }
+
+    const [ch] = await db
+      .select()
+      .from(channelTable)
+      .where(and(eq(channelTable.kind, 'telegram'), eq(channelTable.address, botId)))
+      .limit(1);
+    if (!ch) return c.json({ error: 'channel_not_found' }, 404);
+
+    const botToken = await credentials.get(ch.orgId, 'telegram', 'bot_token');
+    if (!botToken) return c.json({ error: 'telegram_bot_token_missing' }, 500);
+
+    const result = await runtime.handleInbound({
+      channelId: ch.id,
+      identifierKind: 'telegram_user_id',
+      identifierValue: String(from.id),
+      content: message.text,
+    });
+
+    await sendTelegramMessage({
+      botToken,
+      chatId: message.chat.id,
+      text: result.reply,
+      fetch: telegramFetch,
+    });
+
+    return c.json({ ok: true }, 200);
+  });
+
+  router.post('/send', async (c) => {
+    const orgId = await resolveOrgId(c, db);
+    if (!orgId) return c.json({ error: 'unauthenticated' }, 401);
+    const json = await safeJson(c.req.raw);
+    const parsed = v.safeParse(SendBody, json);
+    if (!parsed.success) return c.json({ error: 'invalid_send_shape' }, 400);
+    const { channelId, contactId, content } = parsed.output;
+
+    const [ch] = await db
+      .select()
+      .from(channelTable)
+      .where(and(eq(channelTable.id, channelId), eq(channelTable.orgId, orgId)))
+      .limit(1);
+    if (!ch || ch.kind !== 'telegram') {
+      return c.json({ error: 'channel_not_found' }, 404);
+    }
+
+    const [contactRow] = await db
+      .select()
+      .from(contactTable)
+      .where(and(eq(contactTable.id, contactId), eq(contactTable.orgId, orgId)))
+      .limit(1);
+    if (!contactRow) return c.json({ error: 'contact_not_found' }, 404);
+    if (contactRow.doNotContact) return c.json({ error: 'do_not_contact' }, 409);
+
+    const [tg] = await db
+      .select()
+      .from(identifierTable)
+      .where(
+        and(
+          eq(identifierTable.contactId, contactRow.id),
+          eq(identifierTable.kind, 'telegram_user_id'),
+        ),
+      )
+      .limit(1);
+    if (!tg) return c.json({ error: 'contact_has_no_telegram_id' }, 400);
+
+    // Same resolveSession the inbound webhook uses — invariant #10. When the
+    // contact replies, the inbound webhook will resolve to the same session.
+    const out = await runtime.handleOutbound({
+      channelId,
+      identifierKind: 'telegram_user_id',
+      identifierValue: tg.value,
+      content,
+    });
+
+    const botToken = await credentials.get(orgId, 'telegram', 'bot_token');
+    if (!botToken) return c.json({ error: 'telegram_bot_token_missing' }, 500);
+    const chatId = Number.parseInt(tg.value, 10);
+    if (!Number.isFinite(chatId)) return c.json({ error: 'invalid_chat_id' }, 500);
+    await sendTelegramMessage({
+      botToken,
+      chatId,
+      text: content,
+      fetch: telegramFetch,
+    });
+
+    return c.json({ sessionId: out.sessionId }, 200);
+  });
+
+  return router;
+}
+
+// Subset of Telegram's Update shape we read. Other fields (entities, photos,
+// location, edited_message, callback_query, etc.) ride along on the JSON but
+// don't affect the 1-on-1 text path; we ignore them.
+type TelegramUpdate = {
+  update_id: number;
+  message?: {
+    message_id: number;
+    from?: { id: number; is_bot: boolean };
+    chat: { id: number; type: 'private' | 'group' | 'supergroup' | 'channel' };
+    text?: string;
+  };
+};
+
+async function safeJson(req: Request): Promise<unknown> {
+  try {
+    return await req.json();
+  } catch {
+    return null;
+  }
+}

--- a/apps/server/src/telegram/telegram.ts
+++ b/apps/server/src/telegram/telegram.ts
@@ -1,0 +1,46 @@
+// Telegram bot HTTP helpers.
+//
+// A Telegram bot token has shape `<bot_id>:<auth_string>`, e.g.
+// `123456:ABC-DEF1234`. The bot id is unique per bot — we store it in
+// `channel.address` so the inbound webhook can resolve the channel without
+// trusting a path param alone.
+//
+// Sending: POST application/json to
+//   https://api.telegram.org/bot{token}/sendMessage
+// Tests stub the wire via an injected `fetch` so we can assert on the call
+// without hitting Telegram.
+
+export type FetchLike = (input: string, init: RequestInit) => Promise<Response>;
+
+export type SendMessageArgs = {
+  botToken: string;
+  chatId: number;
+  text: string;
+  fetch?: FetchLike;
+};
+
+export type SentMessage = { messageId: number };
+
+export async function sendTelegramMessage(args: SendMessageArgs): Promise<SentMessage> {
+  const f: FetchLike = args.fetch ?? ((u, i) => fetch(u, i));
+  const url = `https://api.telegram.org/bot${args.botToken}/sendMessage`;
+  const res = await f(url, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ chat_id: args.chatId, text: args.text }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`telegram send failed (${res.status}): ${detail}`);
+  }
+  const json = (await res.json()) as { result?: { message_id?: number } };
+  return { messageId: json.result?.message_id ?? 0 };
+}
+
+// Telegram bot tokens are `<digits>:<auth-string>`. The integer prefix is the
+// bot id; we use it as the channel's stable address so inbound updates can
+// resolve the channel without reading the secret token out of the request.
+export function botIdFromToken(token: string): string | null {
+  const match = /^(\d+):/.exec(token);
+  return match ? match[1]! : null;
+}

--- a/apps/server/src/test-helpers/e2e-server.ts
+++ b/apps/server/src/test-helpers/e2e-server.ts
@@ -22,6 +22,7 @@ import { mountStatic } from '../routes/static.ts';
 import { createCredentialService } from '../credentials/service.ts';
 import { createHeadlessRuntime } from '../headless/runtime.ts';
 import { smsRoute } from '../sms/route.ts';
+import { telegramRoute } from '../telegram/route.ts';
 
 const port = Number.parseInt(process.env.E2E_PORT ?? '4173', 10);
 
@@ -61,6 +62,13 @@ const twilioFetch = async () =>
     headers: { 'content-type': 'application/json' },
   });
 
+// Same reason as twilioFetch: don't hit api.telegram.org from CI.
+const telegramFetch = async () =>
+  new Response(JSON.stringify({ ok: true, result: { message_id: 1 } }), {
+    status: 200,
+    headers: { 'content-type': 'application/json' },
+  });
+
 app.route('/api/auth', authRoute({ db }));
 app.route('/api/agents', agentsRoute({ db }));
 app.route('/api/conversations', conversationsRoute({ db }));
@@ -68,6 +76,7 @@ app.route('/api/channels', channelsRoute({ db, credentials }));
 app.route('/api/email', emailRoute({ db, credentials }));
 app.route('/widget', widgetRoute({ db, sessionRoot, invokeAgent }));
 app.route('/sms', smsRoute({ db, credentials, runtime, twilioFetch }));
+app.route('/telegram', telegramRoute({ db, credentials, runtime, telegramFetch }));
 mountStatic(app);
 
 const server = Bun.serve({ port, fetch: app.fetch });

--- a/apps/web/src/pages/Agents.tsx
+++ b/apps/web/src/pages/Agents.tsx
@@ -576,10 +576,11 @@ function TelegramConnectForm({
   }
 
   // Pull the bot id (digits before the colon) so we can preview the inbound
-  // webhook URL the operator pastes back into Telegram via setWebhook.
-  const botId = /^(\d+):/.exec(draft.botToken)?.[1];
+  // webhook URL the operator pastes back into Telegram via setWebhook. Falls
+  // back to a placeholder until the operator pastes a parseable token.
+  const botId = /^(\d+):/.exec(draft.botToken)?.[1] ?? '<bot_id>';
   const origin = typeof window === 'undefined' ? '' : window.location.origin;
-  const webhookUrl = botId ? `${origin}/telegram/webhook/${botId}` : null;
+  const webhookUrl = `${origin}/telegram/webhook/${botId}`;
 
   return (
     <form
@@ -607,8 +608,7 @@ function TelegramConnectForm({
         <p className="mt-1">
           Tell Telegram where to deliver inbound messages by calling{' '}
           <code className="rounded bg-zinc-800 px-1 font-mono">
-            https://api.telegram.org/bot&lt;token&gt;/setWebhook?url=
-            {webhookUrl ?? `${origin}/telegram/webhook/<bot_id>`}
+            https://api.telegram.org/bot&lt;token&gt;/setWebhook?url={webhookUrl}
           </code>{' '}
           once. We resolve the bot from the URL on every update.
         </p>

--- a/apps/web/src/pages/Agents.tsx
+++ b/apps/web/src/pages/Agents.tsx
@@ -10,6 +10,7 @@ export type Agent = {
   voiceEnabled: boolean;
   widgetChannelId: string | null;
   smsChannel: { id: string; phoneNumber: string } | null;
+  telegramChannel: { id: string; botId: string } | null;
 };
 
 type FormDraft = {
@@ -39,6 +40,12 @@ const EMPTY_SMS_DRAFT: SmsDraft = {
   twilioAuthToken: '',
   phoneNumber: '',
 };
+
+type TelegramDraft = {
+  botToken: string;
+};
+
+const EMPTY_TELEGRAM_DRAFT: TelegramDraft = { botToken: '' };
 
 export function Agents() {
   const [agents, setAgents] = useState<Agent[]>([]);
@@ -230,6 +237,9 @@ export function Agents() {
           void refresh();
         }}
         onConnectEmail={(a) => setConnectEmailFor(a)}
+        onTelegramConnected={() => {
+          void refresh();
+        }}
       />
 
       {connectEmailFor && (
@@ -286,6 +296,7 @@ function AgentList({
   onDelete,
   onSmsConnected,
   onConnectEmail,
+  onTelegramConnected,
 }: {
   loading: boolean;
   agents: Agent[];
@@ -293,8 +304,10 @@ function AgentList({
   onDelete: (a: Agent) => void;
   onSmsConnected: () => void;
   onConnectEmail: (a: Agent) => void;
+  onTelegramConnected: () => void;
 }) {
   const [openSmsAgentId, setOpenSmsAgentId] = useState<string | null>(null);
+  const [openTelegramAgentId, setOpenTelegramAgentId] = useState<string | null>(null);
   if (loading) {
     return <p className="text-zinc-400 text-sm">Loading…</p>;
   }
@@ -335,6 +348,14 @@ function AgentList({
                   SMS: <span className="font-mono">{a.smsChannel.phoneNumber}</span>
                 </div>
               )}
+              {a.telegramChannel && (
+                <div
+                  data-testid={`agent-telegram-channel-${a.id}`}
+                  className="mt-1 truncate text-xs text-zinc-300"
+                >
+                  Telegram bot: <span className="font-mono">{a.telegramChannel.botId}</span>
+                </div>
+              )}
             </div>
             <div className="flex gap-2">
               {!a.smsChannel && (
@@ -347,6 +368,18 @@ function AgentList({
                   className="rounded-md border border-zinc-700 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
                 >
                   {openSmsAgentId === a.id ? 'Cancel' : 'Connect SMS'}
+                </button>
+              )}
+              {!a.telegramChannel && (
+                <button
+                  type="button"
+                  data-testid={`agent-connect-telegram-${a.id}`}
+                  onClick={() =>
+                    setOpenTelegramAgentId(openTelegramAgentId === a.id ? null : a.id)
+                  }
+                  className="rounded-md border border-zinc-700 px-2 py-1 text-xs text-zinc-200 hover:bg-zinc-800"
+                >
+                  {openTelegramAgentId === a.id ? 'Cancel' : 'Connect Telegram'}
                 </button>
               )}
               <button
@@ -382,6 +415,17 @@ function AgentList({
                 onSmsConnected();
               }}
               onCancel={() => setOpenSmsAgentId(null)}
+            />
+          )}
+
+          {openTelegramAgentId === a.id && (
+            <TelegramConnectForm
+              agentId={a.id}
+              onConnected={() => {
+                setOpenTelegramAgentId(null);
+                onTelegramConnected();
+              }}
+              onCancel={() => setOpenTelegramAgentId(null)}
             />
           )}
         </li>
@@ -481,6 +525,106 @@ function SmsConnectForm({
           className="rounded-md bg-emerald-500 px-3 py-1.5 text-sm font-medium text-zinc-950 hover:bg-emerald-400 disabled:opacity-60"
         >
           {submitting ? 'Saving…' : 'Save SMS channel'}
+        </button>
+        <button
+          type="button"
+          onClick={onCancel}
+          className="rounded-md border border-zinc-700 px-3 py-1.5 text-sm text-zinc-200 hover:bg-zinc-800"
+        >
+          Cancel
+        </button>
+      </div>
+    </form>
+  );
+}
+
+function TelegramConnectForm({
+  agentId,
+  onConnected,
+  onCancel,
+}: {
+  agentId: string;
+  onConnected: () => void;
+  onCancel: () => void;
+}) {
+  const [draft, setDraft] = useState<TelegramDraft>(EMPTY_TELEGRAM_DRAFT);
+  const [submitting, setSubmitting] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function onSubmit(e: FormEvent<HTMLFormElement>) {
+    e.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/channels/telegram', {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        credentials: 'same-origin',
+        body: JSON.stringify({ agentId, ...draft }),
+      });
+      if (!res.ok) {
+        const body = (await res.json().catch(() => ({}))) as { error?: string };
+        throw new Error(body.error ?? `Connect failed (${res.status})`);
+      }
+      setDraft(EMPTY_TELEGRAM_DRAFT);
+      onConnected();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Connect failed.');
+    } finally {
+      setSubmitting(false);
+    }
+  }
+
+  // Pull the bot id (digits before the colon) so we can preview the inbound
+  // webhook URL the operator pastes back into Telegram via setWebhook.
+  const botId = /^(\d+):/.exec(draft.botToken)?.[1];
+  const origin = typeof window === 'undefined' ? '' : window.location.origin;
+  const webhookUrl = botId ? `${origin}/telegram/webhook/${botId}` : null;
+
+  return (
+    <form
+      data-testid={`telegram-connect-form-${agentId}`}
+      onSubmit={onSubmit}
+      className="space-y-3 rounded-md border border-zinc-800 bg-zinc-950/40 p-3 text-sm"
+    >
+      <h3 className="font-semibold text-zinc-200">Connect a Telegram bot</h3>
+      <p className="text-xs text-zinc-400">
+        In Telegram, open <span className="text-zinc-200">@BotFather</span>,
+        run <code className="rounded bg-zinc-800 px-1 font-mono">/newbot</code>{' '}
+        (or pick an existing one with{' '}
+        <code className="rounded bg-zinc-800 px-1 font-mono">/mybots</code>),
+        and paste the bot's HTTP API token below. Group chats are deferred to a
+        later release — this slice only handles 1-on-1 chats with the bot.
+      </p>
+      <TextField
+        label="Bot token (e.g. 1234567890:ABC-DEF1234ghIkl-zyx57W2v1u123ew11)"
+        value={draft.botToken}
+        onChange={(botToken) => setDraft((d) => ({ ...d, botToken }))}
+        required
+      />
+      <div className="rounded-md border border-zinc-800 bg-zinc-900/60 p-2 text-xs text-zinc-400">
+        <p className="font-medium text-zinc-300">After saving:</p>
+        <p className="mt-1">
+          Tell Telegram where to deliver inbound messages by calling{' '}
+          <code className="rounded bg-zinc-800 px-1 font-mono">
+            https://api.telegram.org/bot&lt;token&gt;/setWebhook?url=
+            {webhookUrl ?? `${origin}/telegram/webhook/<bot_id>`}
+          </code>{' '}
+          once. We resolve the bot from the URL on every update.
+        </p>
+      </div>
+      {error && (
+        <p role="alert" className="text-sm text-red-400">
+          {error}
+        </p>
+      )}
+      <div className="flex gap-2">
+        <button
+          type="submit"
+          disabled={submitting}
+          className="rounded-md bg-emerald-500 px-3 py-1.5 text-sm font-medium text-zinc-950 hover:bg-emerald-400 disabled:opacity-60"
+        >
+          {submitting ? 'Saving…' : 'Save Telegram channel'}
         </button>
         <button
           type="button"

--- a/tests/e2e/telegram.spec.ts
+++ b/tests/e2e/telegram.spec.ts
@@ -1,0 +1,83 @@
+import { test, expect, request } from '@playwright/test';
+
+// End-to-end: operator connects a Telegram bot via the UI, an inbound
+// Telegram update fires at /telegram/webhook/<botId>, and the operator sees
+// the conversation in the conversation view.
+
+test('Telegram: operator connects a bot, inbound webhook lands in conversation view', async ({
+  page,
+  baseURL,
+}) => {
+  const email = `op+tg+${Date.now()}@example.com`;
+  const password = 'hunter2hunter2';
+  const botId = String(100000 + Math.floor(Math.random() * 899999));
+  const botToken = `${botId}:e2e-token-${Date.now()}`;
+  const visitorChatId = 700000 + Math.floor(Math.random() * 99999);
+
+  await page.goto('/register');
+  await page.getByLabel('Email').fill(email);
+  await page.getByLabel('Password (8+ characters)').fill(password);
+  await page.getByRole('button', { name: 'Create account' }).click();
+  await expect(page.getByTestId('dashboard')).toBeVisible();
+
+  // Create an agent.
+  await page.getByRole('link', { name: 'Agents' }).click();
+  await page.getByRole('button', { name: 'New agent' }).click();
+  await page.getByLabel('Name').fill('Telegram Concierge');
+  await page.getByLabel('Persona').fill('Friendly concierge.');
+  await page.getByLabel('Model').fill('claude-haiku-test');
+  await page.getByRole('button', { name: 'Create agent' }).click();
+  await expect(page.getByTestId('agents-list')).toBeVisible();
+
+  // Open the Telegram connect form. PRD: non-obvious flows need an inline
+  // explanation — assert the BotFather + setWebhook copy is present.
+  await page.getByTestId(/^agent-connect-telegram-/).click();
+  const form = page.getByTestId(/^telegram-connect-form-/);
+  await expect(form).toBeVisible();
+  await expect(form).toContainText(/BotFather/);
+  await expect(form).toContainText('/telegram/webhook/');
+
+  await form
+    .getByLabel(/Bot token/)
+    .fill(botToken);
+  await form.getByRole('button', { name: 'Save Telegram channel' }).click();
+
+  // After save, the row shows the connected bot id.
+  await expect(page.getByTestId(/^agent-telegram-channel-/)).toContainText(botId);
+
+  // Hit the inbound webhook directly with a Telegram-shaped Update — this is
+  // what api.telegram.org POSTs in production once setWebhook is configured.
+  const webhookUrl = `${baseURL!.replace(/\/$/, '')}/telegram/webhook/${botId}`;
+  const ctx = await request.newContext();
+  const res = await ctx.post(webhookUrl, {
+    headers: { 'content-type': 'application/json' },
+    data: {
+      update_id: 1,
+      message: {
+        message_id: 1,
+        from: { id: visitorChatId, is_bot: false, first_name: 'Visitor' },
+        chat: { id: visitorChatId, type: 'private' },
+        date: Math.floor(Date.now() / 1000),
+        text: 'when can I drop by?',
+      },
+    },
+  });
+  expect(res.status()).toBe(200);
+  await ctx.dispose();
+
+  // Operator opens the Conversations page; the Telegram conversation lists,
+  // its detail shows the user message and the agent's reply.
+  await page.getByRole('link', { name: 'Conversations' }).click();
+  await expect(page.getByTestId('conversations-page')).toBeVisible();
+
+  const row = page.getByTestId(/^conversation-row-/);
+  await expect(row.first()).toBeVisible();
+  await row.first().click();
+
+  await expect(page.getByTestId('conversation-message-user')).toContainText(
+    'when can I drop by?',
+  );
+  await expect(page.getByTestId('conversation-message-assistant')).toContainText(
+    'Echo: when can I drop by?',
+  );
+});


### PR DESCRIPTION
## Summary

Adds a Telegram bot channel for 1-on-1 chats end-to-end:

- **Operator API.** `POST /api/channels/telegram` stores the bot token through the per-org credential service and creates a `telegram` channel keyed on the bot id (the integer prefix of the token), so the public webhook can resolve a channel without trusting a path param alone.
- **Inbound.** `POST /telegram/webhook/:botId` runs each Telegram Update through the same headless runtime the widget and SMS channels use, then sends the agent's reply back via `api.telegram.org/bot<token>/sendMessage`. Group chats are dropped for now — v1.0 ships 1-on-1 only.
- **Outbound.** `POST /telegram/send` mirrors the SMS outbound shape and goes through the runtime's `resolveSession`, so proactive sends and the contact's reply land in the same `agent_session` (PRD invariant #10).
- **Operator UI.** New inline connect-Telegram form on the Agents page. Guides operators through `@BotFather`, asks for the bot token, and previews the `setWebhook` URL for the configured bot id.

## Test plan

- [x] `apps/server/src/telegram/inbound.test.ts` — webhook dispatches to agent, sends reply via the Telegram bot API, reuses the session on repeat sends, drops non-private chats, returns 404 for unknown bot ids.
- [x] `apps/server/src/telegram/outbound.test.ts` — outbound + reply land in the same session, `do_not_contact` blocks outbound, cross-org channels return 404.
- [x] `apps/server/src/routes/channels.test.ts` — `POST /api/channels/telegram` stores the bot token, validates the token shape, scopes to org, refuses duplicate bots.
- [x] `tests/e2e/telegram.spec.ts` — operator connects a bot through the UI, the inbound webhook fires, the conversation lands in the conversations view.
- [x] `bun run typecheck` and `bun run --filter @nexus/server test` clean.

Closes #12